### PR TITLE
Added doubleclick Eventcallback to Splitter

### DIFF
--- a/CodeBeam.MudExtensions/Components/Splitter/MudSplitter.razor
+++ b/CodeBeam.MudExtensions/Components/Splitter/MudSplitter.razor
@@ -2,7 +2,7 @@
 @inherits MudComponentBase
 
 <div class="@Classname" style="@Style">
-    <MudSlider @ref="_slider" Class="@SliderClassname" Style="overflow: hidden; z-index: 6" T="double" Min="0" Max="100" Step="@Sensitivity" ValueChanged="UpdateDimensions" Disabled="DisableSlide"/>
+    <MudSlider @ref="_slider" ondblclick="@OnDoubleClick" Class="@SliderClassname" Style="overflow: hidden; z-index: 6" T="double" Min="0" Max="100" Step="@Sensitivity" ValueChanged="UpdateDimensions" Disabled="DisableSlide"/>
 
     <div class="@ContentClassname" style="@StyleContent">
         @StartContent

--- a/CodeBeam.MudExtensions/Components/Splitter/MudSplitter.razor.cs
+++ b/CodeBeam.MudExtensions/Components/Splitter/MudSplitter.razor.cs
@@ -116,7 +116,10 @@ namespace MudExtensions
         [Parameter]
         public EventCallback DimensionChanged { get; set; }
 
-        protected override async Task OnInitializedAsync()
+        [Parameter]
+        public EventCallback OnDoubleClicked { get; set; }
+
+      protected override async Task OnInitializedAsync()
         {
             await base.OnInitializedAsync();
             await UpdateDimensions();
@@ -147,5 +150,10 @@ namespace MudExtensions
             await UpdateDimensions();
         }
 
+        async Task OnDoubleClick()
+        {
+           if (OnDoubleClicked.HasDelegate)
+              await OnDoubleClicked.InvokeAsync();
+        }
     }
 }

--- a/ComponentViewer.Docs/Pages/Examples/SplitterExample1.razor
+++ b/ComponentViewer.Docs/Pages/Examples/SplitterExample1.razor
@@ -3,7 +3,7 @@
 
 <MudGrid>
     <MudItem xs="12" sm="8">
-        <MudSplitter @ref="_splitter" Height="@_height" Color="_color" Bordered="_bordered" DimensionChanged="DimensionChanged" DisableSlide="_disableSlide" DisableMargin="_disableMargin" Sensitivity="_sensitivity" Overlap="true">
+        <MudSplitter @ref="_splitter" Height="@_height" Color="_color" Bordered="_bordered" OnDoubleClicked="@OnDoubleClicked" DimensionChanged="DimensionChanged" DisableSlide="_disableSlide" DisableMargin="_disableMargin" Sensitivity="_sensitivity" Overlap="true">
             <StartContent>
                 <MudText>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</MudText>
             </StartContent>
@@ -42,10 +42,17 @@
     bool _bordered = false;
     bool _disableSlide = false;
     bool _disableMargin = false;
+    bool _enabledDoubleClick = false;
     double _sensitivity = 0.1d;
 
     private void DimensionChanged()
     {
         _percentage = _splitter.GetStartContentPercentage();
+    }
+
+    private void OnDoubleClicked()
+    {
+        _percentage = 50;
+        _splitter.SetDimensions(_percentage);
     }
 }

--- a/ComponentViewer.Docs/Pages/Examples/SplitterExample1.razor
+++ b/ComponentViewer.Docs/Pages/Examples/SplitterExample1.razor
@@ -42,7 +42,6 @@
     bool _bordered = false;
     bool _disableSlide = false;
     bool _disableMargin = false;
-    bool _enabledDoubleClick = false;
     double _sensitivity = 0.1d;
 
     private void DimensionChanged()
@@ -50,9 +49,9 @@
         _percentage = _splitter.GetStartContentPercentage();
     }
 
-    private void OnDoubleClicked()
+    private async Task OnDoubleClicked()
     {
         _percentage = 50;
-        _splitter.SetDimensions(_percentage);
+        await _splitter.SetDimensions(_percentage);
     }
 }


### PR DESCRIPTION
I've added the `ondblclick` to forward this as an `OnDoubleClick` EventCallback to the Splitter component.

In my case there's need for this; when a users double clicks the splitter I execute the callback
to reset the splitter to its original position, for example:
```csharp
private void OnDoubleClicked()
{
    _percentage = 50;
    _splitter.SetDimensions(_percentage);
}
```
