### PR TITLE
MudStepper advanced action controls customisation

### DIFF
--- a/CodeBeam.MudExtensions/Components/Stepper/MudStepper.razor
+++ b/CodeBeam.MudExtensions/Components/Stepper/MudStepper.razor
@@ -70,7 +70,7 @@
 
                 @if (ActionContent != null)
                 {
-                    @* User will will provide their own MudSpacer in this render fragment *@
+                    @* The user will provide their own MudSpacer in this render fragment *@
                     @ActionContent
                 }
                 else

--- a/CodeBeam.MudExtensions/Components/Stepper/MudStepper.razor
+++ b/CodeBeam.MudExtensions/Components/Stepper/MudStepper.razor
@@ -70,10 +70,13 @@
 
                 @if (ActionContent != null)
                 {
+                    @* User will will provide their own MudSpacer in this render fragment *@
                     @ActionContent
                 }
-
-                <MudSpacer />
+                else
+                {
+                    <MudSpacer />
+                }
 
                 @if (showResultStep == false)
                 {

--- a/CodeBeam.MudExtensions/Components/Stepper/MudStepper.razor
+++ b/CodeBeam.MudExtensions/Components/Stepper/MudStepper.razor
@@ -51,50 +51,54 @@
             </div>
             
             <div class="d-flex gap-4">
+                
+                @{
+                    bool showResultStep = ShowResultStep();
+                }
+
+                @if (!DisablePreviousButton && ActiveIndex != 0)
+                {
+                    if (ActiveIndex < Steps.Count && Steps[ActiveIndex].Status != StepStatus.Continued || showResultStep)
+                    {
+                        <MudIconButton Color="@Color" Variant="@Variant" Icon="@Icons.Filled.ChevronLeft" OnClick="@(() => SetActiveIndex(-1))" />
+                    }
+                    else
+                    {
+                        <MudButton Color="@Color" Variant="@Variant" OnClick="@(() => SetActiveIndex(-1))">@LocalizedStrings.Previous</MudButton>
+                    }
+                }
+
                 @if (ActionContent != null)
                 {
                     @ActionContent
                 }
-                else
+
+                <MudSpacer />
+
+                @if (showResultStep == false)
                 {
-                    bool showResultStep = ShowResultStep();
-                    if (ActiveIndex != 0)
+                    if (!DisableStepResultIndicator && (ActiveIndex < Steps.Count && Steps[ActiveIndex].Status != StepStatus.Continued) || (ActiveIndex == Steps.Count - 1 && HasResultStep() == false && IsAllStepsCompleted()))
                     {
-                        if (ActiveIndex < Steps.Count && Steps[ActiveIndex].Status != StepStatus.Continued || showResultStep)
-                        {
-                            <MudIconButton Color="@Color" Variant="@Variant" Icon="@Icons.Filled.ChevronLeft" OnClick="@(() => SetActiveIndex(-1))" />
-                        }
-                        else
-                        {
-                            <MudButton Color="@Color" Variant="@Variant" OnClick="@(() => SetActiveIndex(-1))">@LocalizedStrings.Previous</MudButton>
-                        }
+                        <MudButton Color="@Color" Variant="@Variant" Disabled="true">@(Steps[ActiveIndex].Status == StepStatus.Completed ? LocalizedStrings.Completed : LocalizedStrings.Skipped)</MudButton>
                     }
-
-                    <MudSpacer />
-
-                    if (showResultStep == false)
+                    else if (!DisableSkipButton && ActiveIndex < Steps.Count && Steps[ActiveIndex].Optional == true)
                     {
-                        if ((ActiveIndex < Steps.Count && Steps[ActiveIndex].Status != StepStatus.Continued) || (ActiveIndex == Steps.Count - 1 && HasResultStep() == false && IsAllStepsCompleted()))
-                        {
-                            <MudButton Color="@Color" Variant="@Variant" Disabled="true">@(Steps[ActiveIndex].Status == StepStatus.Completed ? LocalizedStrings.Completed : LocalizedStrings.Skipped)</MudButton>
-                        }
-                        else if (ActiveIndex < Steps.Count && Steps[ActiveIndex].Optional == true)
-                        {
-                            <MudButton Color="@Color" Variant="@Variant" OnClick="@(() => SkipStep(ActiveIndex))">@LocalizedStrings.Skip</MudButton>
-                        }
+                        <MudButton Color="@Color" Variant="@Variant" OnClick="@(() => SkipStep(ActiveIndex))">@LocalizedStrings.Skip</MudButton>
                     }
-                    if (showResultStep == false && !(ActiveIndex == Steps.Count - 1 && HasResultStep() == false && IsAllStepsCompleted()))
-                    {
-                        if (ActiveIndex < Steps.Count && Steps[ActiveIndex].Status != StepStatus.Continued)
-                        {
-                            <MudIconButton Color="@Color" Variant="@Variant" Icon="@Icons.Filled.ChevronRight" OnClick="@(() => SetActiveIndex(1))" />
-                        }
-                        else
-                        {
-                            <MudButton Color="@Color" Variant="@Variant" OnClick="@(() => CompleteStep(ActiveIndex))">@GetNextButtonString()</MudButton>
-                        }
-                    }  
                 }
+
+                @if (showResultStep == false && !DisableNextButton && !(ActiveIndex == Steps.Count - 1 && HasResultStep() == false && IsAllStepsCompleted()))
+                {
+                    if (ActiveIndex < Steps.Count && Steps[ActiveIndex].Status != StepStatus.Continued)
+                    {
+                        <MudIconButton Color="@Color" Variant="@Variant" Icon="@Icons.Filled.ChevronRight" OnClick="@(() => SetActiveIndex(1))" />
+                    }
+                    else
+                    {
+                        <MudButton Color="@Color" Variant="@Variant" OnClick="@(() => CompleteStep(ActiveIndex))">@GetNextButtonString()</MudButton>
+                    }
+                }
+
             </div>
         </MudStack>
     </MudStack>

--- a/CodeBeam.MudExtensions/Components/Stepper/MudStepper.razor
+++ b/CodeBeam.MudExtensions/Components/Stepper/MudStepper.razor
@@ -77,13 +77,19 @@
 
                 @if (showResultStep == false)
                 {
-                    if (!DisableStepResultIndicator && (ActiveIndex < Steps.Count && Steps[ActiveIndex].Status != StepStatus.Continued) || (ActiveIndex == Steps.Count - 1 && HasResultStep() == false && IsAllStepsCompleted()))
+                    if ((ActiveIndex < Steps.Count && Steps[ActiveIndex].Status != StepStatus.Continued) || (ActiveIndex == Steps.Count - 1 && HasResultStep() == false && IsAllStepsCompleted()))
                     {
-                        <MudButton Color="@Color" Variant="@Variant" Disabled="true">@(Steps[ActiveIndex].Status == StepStatus.Completed ? LocalizedStrings.Completed : LocalizedStrings.Skipped)</MudButton>
+                        if (!DisableStepResultIndicator)
+                        {
+                            <MudButton Color="@Color" Variant="@Variant" Disabled="true">@(Steps[ActiveIndex].Status == StepStatus.Completed ? LocalizedStrings.Completed : LocalizedStrings.Skipped)</MudButton>
+                        }
                     }
-                    else if (!DisableSkipButton && ActiveIndex < Steps.Count && Steps[ActiveIndex].Optional == true)
+                    else if (ActiveIndex < Steps.Count && Steps[ActiveIndex].Optional == true)
                     {
+                        if (!DisableSkipButton)
+                        {
                         <MudButton Color="@Color" Variant="@Variant" OnClick="@(() => SkipStep(ActiveIndex))">@LocalizedStrings.Skip</MudButton>
+                        }
                     }
                 }
 

--- a/CodeBeam.MudExtensions/Components/Stepper/MudStepper.razor.cs
+++ b/CodeBeam.MudExtensions/Components/Stepper/MudStepper.razor.cs
@@ -73,6 +73,30 @@ namespace MudExtensions
         public bool DisableAnimation { get; set; }
 
         /// <summary>
+        /// If true, disables built-in "previous" step action button.
+        /// </summary>
+        [Parameter]
+        public bool DisablePreviousButton { get; set; }
+
+        /// <summary>
+        /// If true, disables built-in "next" step action button.
+        /// </summary>
+        [Parameter]
+        public bool DisableNextButton { get; set; }
+
+        /// <summary>
+        /// If true, disables built-in "skip" step action button.
+        /// </summary>
+        [Parameter]
+        public bool DisableSkipButton { get; set; }
+
+        /// <summary>
+        /// If true, disables built-in "completed"/"skipped" step result indictors shown in the actions panel.
+        /// </summary>
+        [Parameter]
+        public bool DisableStepResultIndicator { get; set; }
+
+        /// <summary>
         /// The predefined Mud color for header and action buttons.
         /// </summary>
         [Parameter]

--- a/CodeBeam.MudExtensions/Components/Stepper/MudStepper.razor.cs
+++ b/CodeBeam.MudExtensions/Components/Stepper/MudStepper.razor.cs
@@ -131,8 +131,12 @@ namespace MudExtensions
         public RenderFragment ChildContent { get; set; }
 
         /// <summary>
-        /// Overrides the action buttons (previous, next etc.) with custom render fragment.
+        /// Custom content to be shown between the "previous" and "next" action buttons.
         /// </summary>
+        /// <remarks>
+        /// If set, you must also supply a <code><MudSpacer /></code> somewhere in your render fragment
+        /// to ensure that the built-in action buttons are aligned correctly.
+        /// </remarks>
         [Parameter]
         public RenderFragment ActionContent { get; set; }
 

--- a/ComponentViewer.Docs/Pages/Examples/StepperExample1.razor
+++ b/ComponentViewer.Docs/Pages/Examples/StepperExample1.razor
@@ -51,6 +51,7 @@
                 {
                     <MudButton Color="Color.Secondary" Variant="_variant" OnClick="@(() => NavigationManager.NavigateTo("/"))">Cancel</MudButton>
                 }
+                <MudSpacer />
             </ActionContent>
         </MudStepper>
     </MudItem>

--- a/ComponentViewer.Docs/Pages/Examples/StepperExample1.razor
+++ b/ComponentViewer.Docs/Pages/Examples/StepperExample1.razor
@@ -1,47 +1,57 @@
 ﻿@inject ISnackbar Snackbar
+@inject NavigationManager NavigationManager
 @using MudBlazor.Extensions
 @using MudExtensions.Utilities
 
 <MudGrid Class="cursor-default">
     <MudItem xs="12" sm="8">
-        <MudStepper @ref="_stepper" ContentStyle="min-height: 400px" Linear="_linear" Vertical="_vertical" Color="_color" Variant="_variant" DisableAnimation="_disableAnimation" HeaderTextView="_headerTextView"
+        <MudStepper @ref="_stepper" ContentStyle="min-height: 400px" Linear="_linear" Vertical="_vertical" Color="_color" Variant="_variant" 
+                    DisableAnimation="_disableAnimation" DisablePreviousButton="_disablePreviousButton" DisableNextButton="_disableNextButton" 
+                    DisableSkipButton="_disableSkipButton" DisableStepResultIndicator="_disableStepResultIndicator" HeaderTextView="_headerTextView"
                     PreventStepChange="new Func<bool>(CheckChange)" LocalizedStrings="GetLocalizedStrings()">
-
-            <MudStep Title="Customer Info" StatusChanged="StatusChanged">
-                <MudForm @ref="_form">
-                    <MudStack>
-                        <MudTextField T="string" Label="Name" Variant="_variant" Required="true" />
-                        <MudTextField T="string" Label="Last Name" Variant="_variant" />
-                        <MudTextField T="string" Label="Adress" Variant="_variant" />
-                    </MudStack>
-                </MudForm>
-            </MudStep>
-            <MudStep Title="Booking Spec." Optional="true">
-                <MudCheckBox T="bool" Label="Early Check-in" Color="_color" />
-                <MudCheckBox T="bool" Label="Late Check-out" Color="_color" />
-                <MudCheckBox T="bool" Label="Twin Bed" Color="_color" />
-            </MudStep>
-            <MudStep Title="Payment">
-                <MudForm @ref="_form2">
-                    <MudStack>
-                        <MudTextField T="string" Label="Card Number" Variant="_variant" Required="true" />
-                        <MudStack Row="true">
-                            <MudTextField T="string" Label="Expire Date" Variant="_variant" Required="true" />
-                            <MudTextField T="string" Label="CVC" Variant="_variant" Required="true" />
+            <ChildContent>
+                <MudStep Title="Customer Info" StatusChanged="StatusChanged">
+                    <MudForm @ref="_form">
+                        <MudStack>
+                            <MudTextField T="string" Label="Name" Variant="_variant" Required="true" />
+                            <MudTextField T="string" Label="Last Name" Variant="_variant" />
+                            <MudTextField T="string" Label="Adress" Variant="_variant" />
                         </MudStack>
-                    </MudStack>
-                </MudForm>
-            </MudStep>
-
-            @if (_addResultStep)
-            {
-                <MudStep Title="Result Step" IsResultStep="true">
-                    <div class="d-flex flex-column align-center justify-center" style="height: 200px">
-                        <MudIconButton Icon="@Icons.Filled.DoneAll" Size="Size.Large" Variant="Variant.Filled" Color="Color.Success" />
-                        <MudText>Your reservation succesfully completed.</MudText>
-                    </div>
+                    </MudForm>
                 </MudStep>
-            }
+                <MudStep Title="Booking Spec." Optional="true">
+                    <MudCheckBox T="bool" Label="Early Check-in" Color="_color" />
+                    <MudCheckBox T="bool" Label="Late Check-out" Color="_color" />
+                    <MudCheckBox T="bool" Label="Twin Bed" Color="_color" />
+                </MudStep>
+                <MudStep Title="Payment">
+                    <MudForm @ref="_form2">
+                        <MudStack>
+                            <MudTextField T="string" Label="Card Number" Variant="_variant" Required="true" />
+                            <MudStack Row="true">
+                                <MudTextField T="string" Label="Expire Date" Variant="_variant" Required="true" />
+                                <MudTextField T="string" Label="CVC" Variant="_variant" Required="true" />
+                            </MudStack>
+                        </MudStack>
+                    </MudForm>
+                </MudStep>
+
+                @if (_addResultStep)
+                {
+                    <MudStep Title="Result Step" IsResultStep="true">
+                        <div class="d-flex flex-column align-center justify-center" style="height: 200px">
+                            <MudIconButton Icon="@Icons.Filled.DoneAll" Size="Size.Large" Variant="Variant.Filled" Color="Color.Success" />
+                            <MudText>Your reservation succesfully completed.</MudText>
+                        </div>
+                    </MudStep>
+                }
+            </ChildContent>
+            <ActionContent>
+                @if (!_stepper.IsAllStepsCompleted())
+                {
+                    <MudButton Color="Color.Secondary" Variant="_variant" OnClick="@(() => NavigationManager.NavigateTo("/"))">Cancel</MudButton>
+                }
+            </ActionContent>
         </MudStepper>
     </MudItem>
 
@@ -49,6 +59,10 @@
         <MudStack Spacing="4">
             <MudCheckBox @bind-Checked="_linear" Color="Color.Primary" Label="Linear" Dense="true" />
             <MudCheckBox @bind-Checked="_disableAnimation" Color="Color.Primary" Label="Disable Animation" Dense="true" />
+            <MudCheckBox @bind-Checked="_disablePreviousButton" Color="Color.Primary" Label="Disable Previous Step Action Button" Dense="true" />
+            <MudCheckBox @bind-Checked="_disableNextButton" Color="Color.Primary" Label="Disable Next Step Action Button" Dense="true" />
+            <MudCheckBox @bind-Checked="_disableSkipButton" Color="Color.Primary" Label="Disable Skip Step Action Button" Dense="true" />
+            <MudCheckBox @bind-Checked="_disableStepResultIndicator" Color="Color.Primary" Label="Disable Step Result Indicator" Dense="true" />
             <MudSwitch @bind-Checked="_addResultStep" Color="Color.Primary" Label="Has Result Step" />
             <MudSwitch @bind-Checked="_checkValidationBeforeComplete" Color="Color.Primary" Label="Check Validation Before Complete Step" />
             <MudSwitch @bind-Checked="_customLocalization" Color="Color.Primary" Label="Custom Localization (German)" />
@@ -84,6 +98,10 @@
     Variant _variant = Variant.Filled;
     HeaderTextView _headerTextView = HeaderTextView.All;
     bool _disableAnimation = false;
+    bool _disablePreviousButton = false;
+    bool _disableNextButton = false;
+    bool _disableSkipButton = false;
+    bool _disableStepResultIndicator = false;
     bool _addResultStep = true;
     bool _customLocalization = false;
     Color _color = Color.Primary;


### PR DESCRIPTION
`MudStepper.ActionContent` can now be used to inject custom action buttons inline with the existing action buttons, rather than replacing them entirely. This might have been intentional, but there are users (like myself) who would want to add custom actions without loosing all of the existing functionality.

Individual components of the action panel can also be disabled, if (for example) you don't want to show the "completed"/"skipped" indicator, or wanted to have a "forward only" stepper without a previous button.

![mudstepper_actions](https://user-images.githubusercontent.com/123988/211938800-ad0626b8-b6b5-40aa-a361-f2c2d2129b33.gif)

### Migration
This is a UI breaking change if you are using `MudStepper.ActionContent`.
To migrate, add `<MudSpacer />` somewhere inside your action content render fragment.