### PR TITLE
MudSelectExtended: Fix Escape Key Not Working

### DIFF
--- a/CodeBeam.MudExtensions/Components/InputExtended/MudDebouncedInputExtended.cs
+++ b/CodeBeam.MudExtensions/Components/InputExtended/MudDebouncedInputExtended.cs
@@ -1,0 +1,123 @@
+﻿using System.Threading.Tasks;
+using System.Timers;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace MudExtensions
+{
+    public abstract class MudDebouncedInputExtended<T> : MudBaseInputExtended<T>
+    {
+        private System.Timers.Timer _timer;
+        private double _debounceInterval;
+
+        /// <summary>
+        /// Interval to be awaited in milliseconds before changing the Text value
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Behavior)]
+        public double DebounceInterval
+        {
+            get => _debounceInterval;
+            set
+            {
+                if (NumericConverter<double>.AreEqual(_debounceInterval, value))
+                    return;
+                _debounceInterval = value;
+                if (_debounceInterval == 0)
+                {
+                    // not debounced, dispose timer if any
+                    ClearTimer(suppressTick: false);
+                    return;
+                }
+                SetTimer();
+            }
+        }
+
+        /// <summary>
+        /// callback to be called when the debounce interval has elapsed
+        /// receives the Text as a parameter
+        /// </summary>
+        [Parameter] public EventCallback<string> OnDebounceIntervalElapsed { get; set; }
+
+        protected Task OnChange()
+        {
+            if (DebounceInterval > 0 && _timer != null)
+            {
+                _timer.Stop();
+                return base.UpdateValuePropertyAsync(false);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        protected override Task UpdateValuePropertyAsync(bool updateText)
+        {
+            // This method is called when Value property needs to be refreshed from the current Text property, so typically because Text property has changed.
+            // We want to debounce only text-input, not a value being set, so the debouncing is only done when updateText==false (because that indicates the
+            // change came from a Text setter)
+            if (updateText)
+            {
+                // we have a change coming not from the Text setter, no debouncing is needed
+                return base.UpdateValuePropertyAsync(updateText);
+            }
+            // if debounce interval is 0 we update immediately
+            if (DebounceInterval <= 0 || _timer == null)
+                return base.UpdateValuePropertyAsync(updateText);
+            // If a debounce interval is defined, we want to delay the update of Value property.
+            _timer.Stop();
+            // restart the timer while user is typing
+            _timer.Start();
+            return Task.CompletedTask;
+        }
+
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+            // if input is to be debounced, makes sense to bind the change of the text to oninput
+            // so we set Immediate to true
+            if (DebounceInterval > 0)
+                Immediate = true;
+        }
+
+        private void SetTimer()
+        {
+            if (_timer == null)
+            {
+                _timer = new System.Timers.Timer();
+                _timer.Elapsed += OnTimerTick;
+                _timer.AutoReset = false;
+            }
+            _timer.Interval = DebounceInterval;
+        }
+
+        private void OnTimerTick(object sender, ElapsedEventArgs e)
+        {
+            InvokeAsync(OnTimerTickGuiThread).AndForget();
+        }
+
+        private async Task OnTimerTickGuiThread()
+        {
+            await base.UpdateValuePropertyAsync(false);
+            await OnDebounceIntervalElapsed.InvokeAsync(Text);
+        }
+
+        private void ClearTimer(bool suppressTick = false)
+        {
+            if (_timer == null)
+                return;
+            var wasEnabled = _timer.Enabled;
+            _timer.Stop();
+            _timer.Elapsed -= OnTimerTick;
+            _timer.Dispose();
+            _timer = null;
+            if (wasEnabled && !suppressTick)
+                OnTimerTickGuiThread().AndForget();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            ClearTimer(suppressTick: true);
+        }
+    }
+}

--- a/CodeBeam.MudExtensions/Components/InputExtended/MudInputCssHelperExtended.cs
+++ b/CodeBeam.MudExtensions/Components/InputExtended/MudInputCssHelperExtended.cs
@@ -10,8 +10,6 @@ namespace MudExtensions
         public static string GetClassname<T>(MudBaseInputExtended<T> baseInput, Func<bool> shrinkWhen) =>
             new CssBuilder("mud-input")
                 .AddClass($"mud-input-{baseInput.Variant.ToDescriptionString()}")
-                //.AddClass($"mud-input-adorned-start", baseInput.AdornmentStart != null)
-                //.AddClass($"mud-input-adorned-end", baseInput.AdornmentEnd != null)
                 .AddClass($"mud-input-margin-{baseInput.Margin.ToDescriptionString()}", when: () => baseInput.Margin != Margin.None)
                 .AddClass("mud-input-underline", when: () => baseInput.DisableUnderLine == false && baseInput.Variant != Variant.Outlined)
                 .AddClass("mud-shrink", when: shrinkWhen)
@@ -26,10 +24,8 @@ namespace MudExtensions
             new CssBuilder("mud-input-slot")
                 .AddClass("mud-input-root")
                 .AddClass($"mud-input-root-{baseInput.Variant.ToDescriptionString()}")
-                //.AddClass($"mud-input-root-adorned-start", baseInput.AdornmentStart != null)
-                //.AddClass($"mud-input-root-adorned-end", baseInput.AdornmentEnd != null)
                 .AddClass($"mud-input-root-margin-{baseInput.Margin.ToDescriptionString()}", when: () => baseInput.Margin != Margin.None)
-                .AddClass("ms-4", baseInput.Variant == Variant.Text)
+                .AddClass("ms-4", baseInput.AdornmentStart != null && baseInput.Variant == Variant.Text)
                 .AddClass(baseInput.Class)
                 .Build();
 

--- a/CodeBeam.MudExtensions/Components/ListExtended/MudListExtended.razor.cs
+++ b/CodeBeam.MudExtensions/Components/ListExtended/MudListExtended.razor.cs
@@ -796,6 +796,14 @@ namespace MudExtensions
                         }
                     }
                     break;
+                case "f":
+                case "F":
+                    if (obj.CtrlKey == true && obj.ShiftKey == true)
+                    {
+                        SearchBox = !SearchBox;
+                        StateHasChanged();
+                    }
+                    break;
             }
             await OnKeyDown.InvokeAsync(obj);
         }

--- a/CodeBeam.MudExtensions/Components/SelectExtended/MudSelectItemExtended.razor.cs
+++ b/CodeBeam.MudExtensions/Components/SelectExtended/MudSelectItemExtended.razor.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using MudBlazor.Utilities;
+using MudExtensions.Extensions;
 
 namespace MudExtensions
 {
@@ -137,13 +138,17 @@ namespace MudExtensions
         protected void HandleOnClick()
         {
             // Selection works on list. We arrange only popover state and some minor arrangements on click.
-            MudSelectExtended?.SelectOption(Value).AndForget();
+            MudSelectExtended?.SelectOption(Value).AndForgetExt();
             InvokeAsync(StateHasChanged);
             if (MultiSelection == false)
             {
-                MudSelectExtended.CloseMenu().AndForget();
+                MudSelectExtended.CloseMenu().AndForgetExt();
             }
-            OnClick.InvokeAsync().AndForget();
+            else
+            {
+                MudSelectExtended.FocusAsync().AndForgetExt();
+            }
+            OnClick.InvokeAsync().AndForgetExt();
         }
 
         protected bool GetDisabledStatus()

--- a/CodeBeam.MudExtensions/Components/TextFieldExtended/MudTextFieldExtended.razor
+++ b/CodeBeam.MudExtensions/Components/TextFieldExtended/MudTextFieldExtended.razor
@@ -1,65 +1,65 @@
 ﻿@namespace MudExtensions
 @typeparam T
-@inherits MudDebouncedInput<T>
+@inherits MudDebouncedInputExtended<T>
 
 <CascadingValue Name="SubscribeToParentForm2" Value="@SubscribeToParentForm2" IsFixed="true">
-    <MudInputControl Label="@Label"
-                     Variant="@Variant"
-                     HelperText="@HelperText"
-                     HelperTextOnFocus="@HelperTextOnFocus"
-                     CounterText="@GetCounterText()"
-                     FullWidth="@FullWidth"
-                     Class="@Classname"
-                     Error="@HasErrors"
-                     ErrorText="@GetErrorText()"
-                     ErrorId="@ErrorId"
-                     Disabled="@Disabled"
-                     Margin="@Margin"
-                     Required="@Required"
-                     ForId="@FieldId">
-        <InputContent>
-            <CascadingValue Name="SubscribeToParentForm2" Value="false" IsFixed="true">
-                @if (_mask == null)
-                {
-                    <MudInputExtended T="string"
-                              @ref="InputReference"
-                              @attributes="UserAttributes"
-                              InputType="@InputType"
-                              Lines="@Lines"
-                              Style="@Style"
-                              Variant="@Variant"
-                              TextUpdateSuppression="@TextUpdateSuppression"
-                              Value="@Text"
-                              ValueChanged="(s) => SetTextAsync(s)"
-                              Placeholder="@Placeholder"
-                              Disabled=@Disabled
-                              DisableUnderLine="@DisableUnderLine"
-                              ReadOnly="@ReadOnly"
-                              MaxLength="@MaxLength"
-                              IconSize="@IconSize"
-                              Error="@Error"
-                              ErrorId="@ErrorId"
-                              Immediate="@Immediate"
-                              Margin="@Margin"
-                              OnBlur="@OnBlurred"
-                              OnKeyDown="@InvokeKeyDown"
-                              OnInternalInputChanged="OnChange"
-                              OnKeyPress="@InvokeKeyPress"
-                              OnKeyUp="@InvokeKeyUp"
-                              KeyDownPreventDefault="KeyDownPreventDefault"
-                              KeyPressPreventDefault="KeyPressPreventDefault"
-                              KeyUpPreventDefault="KeyUpPreventDefault"
-                              HideSpinButtons="true"
-                              Clearable="@Clearable"
-                              OnClearButtonClick="@OnClearButtonClick"
-                              Pattern="@Pattern"
-                              AdornmentStart="@AdornmentStart"
-                              AdornmentEnd="@AdornmentEnd"
-                              AutoSize="AutoSize" />
-                }
-                else
-                {
-                    <MudMask @ref="_maskReference"
+        <MudInputControl Label="@Label"
+                         Variant="@Variant"
+                         HelperText="@HelperText"
+                         HelperTextOnFocus="@HelperTextOnFocus"
+                         CounterText="@GetCounterText()"
+                         FullWidth="@FullWidth"
+                         Class="@Classname"
+                         Error="@HasErrors"
+                         ErrorText="@GetErrorText()"
+                         ErrorId="@ErrorId"
+                         Disabled="@Disabled"
+                         Margin="@Margin"
+                         Required="@Required"
+                         ForId="@FieldId">
+            <InputContent>
+                <CascadingValue Name="SubscribeToParentForm2" Value="false" IsFixed="true">
+                    @if (_mask == null)
+                    {
+                        <MudInputExtended T="string"
+                                      @ref="InputReference"
+                                      @attributes="UserAttributes"
+                                      InputType="@InputType"
+                                      Lines="@Lines"
+                                      Style="@Style"
+                                      Variant="@Variant"
+                                      TextUpdateSuppression="@TextUpdateSuppression"
+                                      Value="@Text"
+                                      ValueChanged="(s) => SetTextAsync(s)"
+                                      Placeholder="@Placeholder"
+                                      Disabled=@Disabled
+                                      DisableUnderLine="@DisableUnderLine"
+                                      ReadOnly="@ReadOnly"
+                                      MaxLength="@MaxLength"
+                                      IconSize="@IconSize"
+                                      Error="@Error"
+                                      ErrorId="@ErrorId"
+                                      Immediate="@Immediate"
+                                      Margin="@Margin"
+                                      OnBlur="@OnBlurred"
+                                      OnKeyDown="@InvokeKeyDown"
+                                      OnInternalInputChanged="OnChange"
+                                      OnKeyPress="@InvokeKeyPress"
+                                      OnKeyUp="@InvokeKeyUp"
+                                      KeyDownPreventDefault="KeyDownPreventDefault"
+                                      KeyPressPreventDefault="KeyPressPreventDefault"
+                                      KeyUpPreventDefault="KeyUpPreventDefault"
+                                      HideSpinButtons="true"
+                                      Clearable="@Clearable"
+                                      OnClearButtonClick="@OnClearButtonClick"
+                                      Pattern="@Pattern"
+                                      AdornmentStart="@AdornmentStart"
+                                      AdornmentEnd="@AdornmentEnd"
+                                      AutoSize="AutoSize" />
+                    }
+                    else
+                    {
+                        <MudMask @ref="_maskReference"
                              @attributes="UserAttributes"
                              Mask="@_mask"
                              InputType="@InputType"
@@ -80,10 +80,10 @@
                              Margin="@Margin" OnBlur="@OnBlurred"
                              Clearable="@Clearable"
                              OnClearButtonClick="@OnClearButtonClick"
-                            AdornmentStart="@AdornmentStart"
-                            AdornmentEnd="@AdornmentEnd" />
-                }
-            </CascadingValue>
-        </InputContent>
+                             AdornmentStart="@AdornmentStart"
+                             AdornmentEnd="@AdornmentEnd" />
+                    }
+                </CascadingValue>
+            </InputContent>
     </MudInputControl>
 </CascadingValue>

--- a/CodeBeam.MudExtensions/Components/TextFieldExtended/MudTextFieldExtended.razor.cs
+++ b/CodeBeam.MudExtensions/Components/TextFieldExtended/MudTextFieldExtended.razor.cs
@@ -7,7 +7,7 @@ using MudBlazor.Utilities;
 
 namespace MudExtensions
 {
-    public partial class MudTextFieldExtended<T> : MudDebouncedInput<T>
+    public partial class MudTextFieldExtended<T> : MudDebouncedInputExtended<T>
     {
         protected string Classname =>
            new CssBuilder("mud-input-input-control")
@@ -32,7 +32,7 @@ namespace MudExtensions
         [Category(CategoryTypes.FormComponent.Behavior)]
         public InputType InputType { get; set; } = InputType.Text;
 
-        internal InputType GetInputType() => InputType;
+        internal override InputType GetInputType() => InputType;
 
         private string GetCounterText() => Counter == null ? string.Empty : (Counter == 0 ? (string.IsNullOrEmpty(Text) ? "0" : $"{Text.Length}") : ((string.IsNullOrEmpty(Text) ? "0" : $"{Text.Length}") + $" / {Counter}"));
 
@@ -47,17 +47,6 @@ namespace MudExtensions
         /// Button click event for clear button. Called after text and value has been cleared.
         /// </summary>
         [Parameter] public EventCallback<MouseEventArgs> OnClearButtonClick { get; set; }
-
-        /// <summary>
-        /// The adornment that placed start of the input.
-        /// </summary>
-        [Parameter] public RenderFragment AdornmentStart { get; set; }
-
-        /// <summary>
-        /// The adornment that placed end of the input.
-        /// </summary>
-        [Parameter] public RenderFragment AdornmentEnd { get; set; }
-
 
         public override ValueTask FocusAsync()
         {

--- a/ComponentViewer.Docs/Pages/Components/SelectExtendedPage.razor
+++ b/ComponentViewer.Docs/Pages/Components/SelectExtendedPage.razor
@@ -10,7 +10,7 @@
         <SelectExtendedExample1 />
     </ExampleCard>
 
-    <ExampleCard ExampleName="SelectExtendedExample6" Title="SearchBox" Description="SearchBox can be added if items populated with ItemCollection parameter.">
+    <ExampleCard ExampleName="SelectExtendedExample6" Title="SearchBox" Description="SearchBox can be added if items populated with ItemCollection parameter. Ctrl+Shift+F combination shows/hides the searchbox if the box not focused.">
         <SelectExtendedExample6 />
     </ExampleCard>
 


### PR DESCRIPTION
- Fixes that escape key doesn't work when clicked one of the items on multiselection.
- Fixes input text margin on select.
- Added Ctrl+Shift+F key to show/hide searchbox on extended select.