### PR TITLE
Added SearchBoxAutoFocus to Extended (Select & List), Updated Docs Example.

### DIFF
--- a/CodeBeam.MudExtensions/Components/ListExtended/MudListExtended.razor
+++ b/CodeBeam.MudExtensions/Components/ListExtended/MudListExtended.razor
@@ -19,7 +19,7 @@
                 <MudListSubheaderExtended T="T" Style="position: sticky; top: -12px; background-color: var(--mud-palette-background); z-index: 10">
                     <div @onkeydown:stopPropagation>
                         <MudTextField @bind-Value="@_searchString" Class="@ClassSearchBox" OnKeyUp="@(() => UpdateSelectedStyles())" Immediate="true" Variant="Variant.Outlined" Margin="Margin.Dense"
-                              Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" IconColor="Color" AutoFocus="@SearchBoxAutoFocus" />
+                              Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color" AutoFocus="@SearchBoxAutoFocus" />
                     </div>
 
                 </MudListSubheaderExtended>

--- a/CodeBeam.MudExtensions/Components/ListExtended/MudListExtended.razor
+++ b/CodeBeam.MudExtensions/Components/ListExtended/MudListExtended.razor
@@ -11,7 +11,7 @@
             <MudListItemExtended T="T" IsFunctional="true" Icon="@SelectAllCheckBoxIcon" IconColor="@Color" Text="@SelectAllText" OverrideMultiSelectionComponent="MultiSelectionComponent.None" OnClick="@(() => SelectAllItems(_allSelected))" OnClickHandlerPreventDefault="true" Dense="@Dense" Class="mb-2" />
             <MudDivider />
         }
-        
+
         @if (ItemCollection != null)
         {
             @if (SearchBox == true)
@@ -19,7 +19,7 @@
                 <MudListSubheaderExtended T="T" Style="position: sticky; top: -12px; background-color: var(--mud-palette-background); z-index: 10">
                     <div @onkeydown:stopPropagation>
                         <MudTextField @bind-Value="@_searchString" Class="@ClassSearchBox" OnKeyUp="@(() => UpdateSelectedStyles())" Immediate="true" Variant="Variant.Outlined" Margin="Margin.Dense"
-                              Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" IconColor="Color" />
+                              Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" IconColor="Color" AutoFocus="@SearchBoxAutoFocus" />
                     </div>
 
                 </MudListSubheaderExtended>

--- a/CodeBeam.MudExtensions/Components/ListExtended/MudListExtended.razor.cs
+++ b/CodeBeam.MudExtensions/Components/ListExtended/MudListExtended.razor.cs
@@ -143,6 +143,13 @@ namespace MudExtensions
         public bool SearchBox { get; set; }
 
         /// <summary>
+        /// If true, the search-box will be focused when the dropdown is opened.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public bool SearchBoxAutoFocus { get; set; }
+
+        /// <summary>
         /// SearchBox's CSS classes, seperated by space.
         /// </summary>
         [Parameter]

--- a/CodeBeam.MudExtensions/Components/SelectExtended/MudSelectExtended.razor
+++ b/CodeBeam.MudExtensions/Components/SelectExtended/MudSelectExtended.razor
@@ -25,7 +25,7 @@
                           Disabled="@Disabled" ReadOnly="true" Error="@Error" ErrorId="@ErrorId"
                           Clearable="@Clearable" OnClearButtonClick="(async (e) => await SelectClearButtonClickHandlerAsync(e))"
                           @attributes="UserAttributes" OnBlur="@OnLostFocus">
-                    
+
                     <AdornmentEnd>
                         <MudIcon Icon="@_currentIcon" Color="@AdornmentColor" Size="@IconSize" @onclick="OnAdornmentClick" />
                     </AdornmentEnd>
@@ -43,7 +43,7 @@
                                 {
                                     <MudText Typo="Typo.body1" Class="mud-text-secondary">@Placeholder</MudText>
                                 }
-                                
+
                                 <MudRender>@GetSelectTextPresenter()</MudRender>
                             }
                             else if (ValuePresenter == ValuePresenter.Chip)
@@ -65,7 +65,7 @@
                                 if (SelectedListItem == null)
                                 {
                                     <MudText Typo="Typo.body1" Class="mud-text-secondary">@Placeholder</MudText>
-                                    
+
                                 }
                                 else if (ItemTemplate != null)
                                 {
@@ -102,12 +102,12 @@
                                  Clickable="true" Color="@Color" Dense="@Dense" ItemCollection="@ItemCollection" Virtualize="@Virtualize" DisablePadding="@DisablePopoverPadding" DisableSelectedItemStyle="@DisableSelectedItemStyle"
                                  MultiSelection="@MultiSelection" MultiSelectionComponent="@MultiSelectionComponent" MultiSelectionAlign="@MultiSelectionAlign" SelectAll="@SelectAll" SelectAllText="@SelectAllText"
                                  CheckedIcon="@CheckedIcon" UncheckedIcon="@UncheckedIcon" IndeterminateIcon="@IndeterminateIcon" SelectValueOnTab="@SelectValueOnTab" Comparer="@Comparer"
-                                 ItemTemplate="@ItemTemplate" ItemSelectedTemplate="@ItemSelectedTemplate" ItemDisabledTemplate="@ItemDisabledTemplate" SearchBox="@SearchBox" ToStringFunc="@ToStringFunc">
+                                 ItemTemplate="@ItemTemplate" ItemSelectedTemplate="@ItemSelectedTemplate" ItemDisabledTemplate="@ItemDisabledTemplate" SearchBox="@SearchBox" SearchBoxAutoFocus="@SearchBoxAutoFocus" ToStringFunc="@ToStringFunc">
                             @ChildContent
 						</MudListExtended>
 					</CascadingValue>
 				</MudPopover>
-			</InputContent>        
+			</InputContent>
 		</MudInputControl>
 	</div>
 

--- a/CodeBeam.MudExtensions/Components/SelectExtended/MudSelectExtended.razor.cs
+++ b/CodeBeam.MudExtensions/Components/SelectExtended/MudSelectExtended.razor.cs
@@ -304,6 +304,14 @@ namespace MudExtensions
         public bool SearchBox { get; set; }
 
         /// <summary>
+        /// If true, the search-box will be focused when the dropdown is opened.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public bool SearchBoxAutoFocus { get; set; }
+
+
+        /// <summary>
         /// If true, prevent scrolling while dropdown is open.
         /// </summary>
         [Parameter]
@@ -461,7 +469,7 @@ namespace MudExtensions
                     SetValueAsync(_selectedValues.LastOrDefault(), false).AndForget();
                     UpdateTextPropertyAsync(false).AndForget();
                 }
-                
+
                 SelectedValuesChanged.InvokeAsync(new HashSet<T>(SelectedValues, _comparer)).AndForget();
                 _selectedValuesSetterStarted = false;
                 //Console.WriteLine("SelectedValues setter ended");

--- a/ComponentViewer.Docs/Pages/Examples/SelectExtendedExample6.razor
+++ b/ComponentViewer.Docs/Pages/Examples/SelectExtendedExample6.razor
@@ -1,18 +1,20 @@
 ﻿
 <MudGrid>
     <MudItem xs="12" sm="8">
-        <MudSelectExtended MultiSelection="@_multiselection" ItemCollection="_states" SearchBox="true" T="string" Label="US States" AnchorOrigin="Origin.BottomCenter" Variant="Variant.Outlined" />
+        <MudSelectExtended MultiSelection="@_multiselection" ItemCollection="_states" SearchBox="true" SearchBoxAutoFocus="@_searchBoxAutoFocus" T="string" Label="US States" AnchorOrigin="Origin.BottomCenter" Variant="Variant.Outlined" />
     </MudItem>
 
     <MudItem xs="12" sm="4">
         <MudStack>
             <MudSwitchM3 @bind-Checked="_multiselection" Color="Color.Primary" Label="MultiSelection" />
+            <MudSwitchM3 @bind-Checked="_searchBoxAutoFocus" Color="Color.Primary" Label="AutoFocus (SearchBox)" />
         </MudStack>
     </MudItem>
 </MudGrid>
 
 @code {
     bool _multiselection;
+    bool _searchBoxAutoFocus;
 
     private string[] _states =
     {


### PR DESCRIPTION
Parameter  **`SearchBoxAutoFocus { get; set;} `**  was added to both MudSelectExtended and MudListExtended. 

This gives the user the ability to enable/disable autofocus when search box is enabled. 

Docs.SelectExtendedExample6.razor was updated to reflect the changes. 

Screenshot of updated Docs Example 
![image](https://user-images.githubusercontent.com/88895890/219119542-d2736c51-afc4-4a09-8eac-1b57c59282a1.png)
