### PR TITLE
SelectExtended: Chip Enhancement

### DIFF
--- a/CodeBeam.MudExtensions/Base/MudBaseInputExtended.cs
+++ b/CodeBeam.MudExtensions/Base/MudBaseInputExtended.cs
@@ -224,6 +224,9 @@ namespace MudExtensions
         [Category(CategoryTypes.FormComponent.Validation)]
         public virtual string Pattern { get; set; }
 
+        [Parameter]
+        public string MockInputStyle { get; set; }
+
         /// <summary>
         /// Derived classes need to override this if they can be something other than text
         /// </summary>

--- a/CodeBeam.MudExtensions/Components/InputExtended/MudInputExtended.razor
+++ b/CodeBeam.MudExtensions/Components/InputExtended/MudInputExtended.razor
@@ -83,7 +83,7 @@
     In Disabled state the tabindex attribute must NOT be set at all or else it will get focus on click
     *@
             <div class="@InputClassname"
-                 style="@("display:"+(InputType == InputType.Hidden && ChildContent != null ? "inline" : "none"))"
+                style="@($"display:{(InputType == InputType.Hidden && ChildContent != null ? "inline" : "none")}; {MockInputStyle}")"
                  @onblur="@OnBlurred" @ref="@_elementReference1">
                     @ChildContent
             </div>
@@ -92,7 +92,7 @@
         {
             @*Note: this div must always be there to avoid crashes in WASM, but it is hidden most of the time except if ChildContent should be shown.*@
             <div class="@InputClassname"
-                 style="@("display:"+(InputType == InputType.Hidden && ChildContent != null ? "inline" : "none"))"
+                 style="@($"display:{(InputType == InputType.Hidden && ChildContent != null ? "inline" : "none")}; {MockInputStyle}")"
                  tabindex="@(InputType == InputType.Hidden && ChildContent != null ? 0 : -1)"
                  @onblur="@OnBlurred" @ref="@_elementReference1">
                     @ChildContent

--- a/CodeBeam.MudExtensions/Components/SelectExtended/MudSelectExtended.razor
+++ b/CodeBeam.MudExtensions/Components/SelectExtended/MudSelectExtended.razor
@@ -17,7 +17,7 @@
 		<MudInputControl Label="@Label" Variant="@Variant" HelperText="@HelperText" HelperTextOnFocus="@HelperTextOnFocus" FullWidth="@FullWidth" Margin="@Margin" Class="@Classname" Style="@Style"
 						 Error="@Error" ErrorText="@ErrorText" ErrorId="@ErrorId" Disabled="@Disabled" @onclick="@ToggleMenu" Required="@Required" ForId="@FieldId">
 			<InputContent>
-                <MudInputExtended @ref="_elementReference" InputType="InputType.Hidden"
+                <MudInputExtended @ref="_elementReference" InputType="InputType.Hidden" MockInputStyle="@(ValuePresenter == ValuePresenter.Chip ? "width: 0px" : null)"
                           Class="@InputClassname" Style="@InputStyle" Margin="@Margin" Placeholder="@Placeholder"
                           Variant="@Variant"
                           TextUpdateSuppression="false"
@@ -29,6 +29,18 @@
                     <AdornmentEnd>
                         <MudIcon Icon="@_currentIcon" Color="@AdornmentColor" Size="@IconSize" @onclick="OnAdornmentClick" />
                     </AdornmentEnd>
+
+                    <DataVisualiser>
+                        @if (ValuePresenter == ValuePresenter.Chip)
+                        {
+                            <MudChipSet Class="d-flex flex-wrap mud-width-full" Style="row-gap: 4px" AllClosable="ChipCloseable" OnClose="ChipClosed">
+                                @foreach (var val in SelectedValues)
+                                {
+                                    <MudChip Class="@ChipClass" Text="@Converter.Set(val)" Color="@Color" Size="@ChipSize" Variant="@ChipVariant" />
+                                }
+                            </MudChipSet>
+                        }
+                    </DataVisualiser>
 
                     <ChildContent>
                         <div class="@TemplateClass">
@@ -54,10 +66,7 @@
                                 }
                                 else
                                 {
-                                    @foreach (var val in SelectedValues)
-                                    {
-                                        <MudChip Class="mt-n1" Text="@Converter.Set(val)" Color="@Color" Size="Size.Small" />
-                                    }
+                                    @*Chips show under DataVisualiser RenderFragment*@
                                 }
                             }
                             else if (ValuePresenter == ValuePresenter.ItemContent)

--- a/CodeBeam.MudExtensions/Components/SelectExtended/MudSelectExtended.razor.cs
+++ b/CodeBeam.MudExtensions/Components/SelectExtended/MudSelectExtended.razor.cs
@@ -225,6 +225,25 @@ namespace MudExtensions
         public bool Virtualize { get; set; }
 
         /// <summary>
+        /// If true, chips has close button and remove from SelectedValues when pressed the close button.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public bool ChipCloseable { get; set; }
+
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public string ChipClass { get; set; }
+
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public Variant ChipVariant { get; set; } = Variant.Filled;
+
+        [Parameter]
+        [Category(CategoryTypes.List.Behavior)]
+        public Size ChipSize { get; set; } = Size.Small;
+
+        /// <summary>
         /// Parameter to define the delimited string separator.
         /// </summary>
         [Parameter]
@@ -1054,6 +1073,12 @@ namespace MudExtensions
                 return SelectedValues?.Count() > 0;
             else
                 return base.HasValue(value);
+        }
+
+        protected async Task ChipClosed(MudChip chip)
+        {
+            SelectedValues = SelectedValues.Where(x => x.Equals(Converter.Get(chip.Text)) == false);
+            await SelectedValuesChanged.InvokeAsync(SelectedValues);
         }
     }
 }

--- a/ComponentViewer.Docs/Pages/Examples/SelectExtendedExample5.razor
+++ b/ComponentViewer.Docs/Pages/Examples/SelectExtendedExample5.razor
@@ -1,7 +1,8 @@
 ﻿
 <MudGrid>
     <MudItem xs="12" sm="8">
-        <MudSelectExtended MultiSelectionTextFunc="@(_radioGroup?.SelectedOption == 1 ? new Func<List<string>, string>(GetMultiSelectionText) : null)" MultiSelection="true" ValuePresenter="_valuePresenter" @bind-Value="value" @bind-SelectedValues="options" T="string" Label="US States" AdornmentIcon="@Icons.Material.Filled.Search" AnchorOrigin="Origin.BottomCenter">
+        <MudSelectExtended MultiSelectionTextFunc="@(_radioGroup?.SelectedOption == 1 ? new Func<List<string>, string>(GetMultiSelectionText) : null)" MultiSelection="true" ValuePresenter="_valuePresenter" @bind-Value="value" @bind-SelectedValues="options" T="string" Label="US States" AnchorOrigin="Origin.BottomCenter"
+                           ChipCloseable="_chipCloseable" ChipSize="_chipSize" ChipVariant="_chipVariant">
             @foreach (var state in states)
             {
                 <MudSelectItemExtended T="string" Value="@state" Text="@state" />
@@ -29,14 +30,20 @@
                     <MudText Typo="Typo.subtitle2">}</MudText>
                 </MudItem>
             </MudGrid>
-    </MudItem>
-</MudGrid>
+            <MudSwitchM3 @bind-Checked="_chipCloseable" Label="Chip Closeable" Color="Color.Primary" />
+            <MudSelectExtended Class="mt-4" ItemCollection="@(Enum.GetValues<Variant>())" @bind-Value="_chipVariant" Label="Chip Variant" Variant="Variant.Outlined" Margin="Margin.Dense" />
+            <MudSelectExtended Class="mt-4" ItemCollection="@(Enum.GetValues<Size>())" @bind-Value="_chipSize" Label="Chip Size" Variant="Variant.Outlined" Margin="Margin.Dense" />
+        </MudItem>
+    </MudGrid>
 
-@code {
+    @code {
     MudRadioGroup<int> _radioGroup;
-    ValuePresenter _valuePresenter = ValuePresenter.Text; 
+    ValuePresenter _valuePresenter = ValuePresenter.Text;
     string value { get; set; } = "Nothing selected";
     IEnumerable<string> options { get; set; } = new HashSet<string>() { "Alaska", "California" };
+    bool _chipCloseable = false;
+    Variant _chipVariant = Variant.Filled;
+    Size _chipSize = Size.Small;
 
     private string[] states =
     {


### PR DESCRIPTION
Fixes #119.

Chips in MudSelectExtended now shown properly, can wrap (multiline) and its variant and size can change by users.