### PR TITLE
Example: Lazy load QR libraries

### DIFF
--- a/ComponentViewer.Wasm/App.razor
+++ b/ComponentViewer.Wasm/App.razor
@@ -1,4 +1,11 @@
-﻿<Router AppAssembly="@typeof(ComponentViewer.Docs.Pages.Index).Assembly">
+﻿@using System.Reflection
+@using Microsoft.AspNetCore.Components.WebAssembly.Services
+@inject LazyAssemblyLoader AssemblyLoader
+@inject ILogger<App> Logger
+
+<Router AppAssembly="@typeof(ComponentViewer.Docs.Pages.Index).Assembly"
+        AdditionalAssemblies="@_lazyLoadedAssemblies" 
+        OnNavigateAsync="@OnNavigateAsync">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(ComponentViewer.Docs.Shared.MainLayout)" />
         <FocusOnNavigate RouteData="@routeData" Selector="h1" />
@@ -10,3 +17,32 @@
         </LayoutView>
     </NotFound>
 </Router>
+
+@code
+{
+    private readonly List<Assembly> _lazyLoadedAssemblies = new();
+
+    private async Task OnNavigateAsync(NavigationContext args)
+    {
+        try
+        {
+            //Route to the component that contains the QR
+            if (args.Path == "mudqrcode")
+            {
+                var assemblies = await AssemblyLoader
+                    .LoadAssembliesAsync(new[]
+                    {
+                        "SkiaSharp.dll",
+                        "zxing.dll",
+                        "ZXing.SkiaSharp.dll",
+                        "SkiaSharp.Views.Blazor.dll"
+                    });
+                _lazyLoadedAssemblies.AddRange(assemblies);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError("Error: {Message}", ex.Message);
+        }
+    }
+}

--- a/ComponentViewer.Wasm/ComponentViewer.Wasm.csproj
+++ b/ComponentViewer.Wasm/ComponentViewer.Wasm.csproj
@@ -5,6 +5,14 @@
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  
+  <!-- List of libs to lazy load for QR -->
+  <ItemGroup>
+    <BlazorWebAssemblyLazyLoad Include="SkiaSharp.dll" />
+    <BlazorWebAssemblyLazyLoad Include="zxing.dll" />
+    <BlazorWebAssemblyLazyLoad Include="ZXing.SkiaSharp.dll" />
+    <BlazorWebAssemblyLazyLoad Include="SkiaSharp.Views.Blazor.dll" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.1" />


### PR DESCRIPTION
Here's an example of how you can implement lazy loading of assemblies in Blazor WebAssembly. Microsoft's documentation provides step-by-step instructions on how to achieve this, and you can find it here: https://learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-lazy-load-assemblies?view=aspnetcore-7.0