### PR TITLE
MudStepper: fix header text not being aligned

### DIFF
--- a/CodeBeam.MudBlazor.Extensions/Components/Stepper/MudStepper.razor
+++ b/CodeBeam.MudBlazor.Extensions/Components/Stepper/MudStepper.razor
@@ -51,7 +51,7 @@
                                 }
                                 @if (HeaderTextView == HeaderTextView.All || HeaderTextView == HeaderTextView.OnlyActiveText)
                                 {
-                                    <MudText Class="mt-n1">
+                                    <MudText Align="Align.Center" Class="mt-n1">
                                         @if (step.MudStepper.GetActiveIndex() == @step.MudStepper.Steps.IndexOf(@step))
                                         {
                                             <MudText Color="@(step.Status != StepStatus.Continued ? Color : Color.Inherit)"><b>@step.Title</b></MudText>


### PR DESCRIPTION
Adds a single attribute to fix text wrapping on longer phrases.
![image](https://github.com/CodeBeamOrg/CodeBeam.MudBlazor.Extensions/assets/67005577/71cf58ed-1c6a-401a-b145-d6154c553f61)
