### PR TITLE
Add missing item.SetSelected call for multi select when pre-selection is provided

### DIFF
--- a/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListExtended.razor
+++ b/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListExtended.razor
@@ -32,7 +32,7 @@
                         {
                             <MudCheckBox CheckedIcon="@SelectAllCheckBoxIcon" Color="@Color" @bind-Checked="_allSelected" @onclick="() => SelectAllItems(_allSelected)" Dense="true" />
                         }
-                        <MudTextField @ref="_searchField" @bind-Value="@_searchString" Class="@ClassSearchBox" Placeholder="@SearchBoxPlaceholder" OnKeyDown="SearchBoxHandleKeyDown" OnKeyUp="@(() => UpdateSelectedStyles())" Immediate="true" Variant="Variant.Outlined" Margin="Margin.Dense"
+                        <MudTextField @ref="_searchField" @bind-Value="@_searchString" Class="@ClassSearchBox" Placeholder="@SearchBoxPlaceholder" OnKeyDown="SearchBoxHandleKeyDown" OnKeyUp="@(() => UpdateSelectedStyles())" OnClearButtonClick="@(() => UpdateSelectedStyles())" Immediate="true" Variant="Variant.Outlined" Margin="Margin.Dense"
                             Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color" AutoFocus="@SearchBoxAutoFocus" Clearable="@SearchBoxClearable" />
                     </div>
                 </MudListSubheaderExtended>

--- a/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListExtended.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListExtended.razor.cs
@@ -762,6 +762,11 @@ namespace MudExtensions
                 //SelectedItem = item;
                 //SelectedItemChanged.InvokeAsync(item);
             }
+
+            if (MultiSelection && SelectedValues != null && SelectedValues.Contains(item.Value))
+            {
+                item.SetSelected(true);
+            }
         }
 
         protected internal void Unregister(MudListItemExtended<T> item)

--- a/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListExtended.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListExtended.razor.cs
@@ -400,7 +400,6 @@ namespace MudExtensions
             else if (changedValueType == "MultiSelectionOff")
             {
                 SelectedValue = SelectedValues == null ? default(T) : SelectedValues.FirstOrDefault();
-                var items = CollectAllMudListItems(true);
                 SelectedValues = SelectedValue == null ? null : new HashSet<T>(_comparer) { SelectedValue };
                 UpdateSelectedItem();
             }
@@ -1073,7 +1072,11 @@ namespace MudExtensions
                 {
                     _allSelected = false;
                 }
-                else if (CollectAllMudListItems(true).Count() == _selectedValues.Count)
+                else if (ItemCollection != null && ItemCollection.Count == _selectedValues.Count)
+                {
+                    _allSelected = true;
+                }
+                else if (ItemCollection == null && CollectAllMudListItems(true).Count() == _selectedValues.Count)
                 {
                     _allSelected = true;
                 }
@@ -1139,7 +1142,15 @@ namespace MudExtensions
                 _allSelected = true;
             }
 
-            SelectedValues = items.Where(x => x.IsSelected).Select(y => y.Value).ToHashSet(_comparer);
+            if (ItemCollection != null)
+            {
+                SelectedValues = deselect == true ? Enumerable.Empty<T>() : ItemCollection.ToHashSet(_comparer);
+            }
+            else
+            {
+                SelectedValues = items.Where(x => x.IsSelected).Select(y => y.Value).ToHashSet(_comparer);
+            }
+
             if (MudSelectExtended != null)
             {
                 MudSelectExtended.BeginValidatePublic();


### PR DESCRIPTION
Add missing item.SetSelected call for multi select when pre-selection is provided.

The issue this resolves is when MultiSelection is on, and SelectedValues is provided by the outside component, the selection is only set for the last item in the selected values instead of all of the values. As soon as you scroll a list it refreshes the selection and shows the selected items correctly. But on first render it's wrong.