### PR TITLE
RadioButtonGroup prototype

### DIFF
--- a/CodeBeam.MudBlazor.Extensions/Components/RadioButton/IMudRadioButtonGroup.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/RadioButton/IMudRadioButtonGroup.cs
@@ -1,0 +1,8 @@
+﻿namespace MudExtensions
+{
+	internal interface IMudRadioButtonGroup
+	{
+		//This interface need to throw exception properly.
+		void CheckGenericTypeMatch(object select_item);
+	}
+}

--- a/CodeBeam.MudBlazor.Extensions/Components/RadioButton/MudRadioButton.razor
+++ b/CodeBeam.MudBlazor.Extensions/Components/RadioButton/MudRadioButton.razor
@@ -1,0 +1,18 @@
+﻿@namespace MudExtensions
+@typeparam T
+@inherits MudComponentBase
+
+<label class="@Classname" style="@Style" id="@_elementId" @onkeydown="@HandleKeyDownAsync">
+	<span tabindex="0" class="@ButtonClassname">
+		<span class="mud-radio-button d-flex flex-grow-1">
+			<input tabindex="-1" @attributes="UserAttributes" aria-checked="@(Checked.ToString().ToLower())" aria-disabled="@(IsDisabled.ToString().ToLower())" role="radio" type="radio" class="mud-radio-input" name="@MudRadioButtonGroup?.Name" disabled="@IsDisabled" @onclick="OnClick" />
+			
+			<MudButton Color="Color" Class="flex-grow-1" Variant="@(Checked ? Variant.Filled : Variant.Outlined)" OnClick="OnClick" Disabled="IsDisabled">
+				@if (ChildContent != null)
+				{
+					<span class="@ChildSpanClassName">@ChildContent</span>
+				}
+			</MudButton>
+		</span>
+	</span>
+</label>

--- a/CodeBeam.MudBlazor.Extensions/Components/RadioButton/MudRadioButton.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/RadioButton/MudRadioButton.razor.cs
@@ -173,10 +173,8 @@ namespace MudExtensions
 					Select();
 					break;
 				case "Backspace":
-					if (MudRadioButtonGroup is not null)
-					{
-						await MudRadioButtonGroup.ResetAsync();
-					}
+					// Should be async on newer versions of MudBlazor.
+					MudRadioButtonGroup?.Reset();
 
 					break;
 			}

--- a/CodeBeam.MudBlazor.Extensions/Components/RadioButton/MudRadioButton.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/RadioButton/MudRadioButton.razor.cs
@@ -1,0 +1,224 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor;
+using MudBlazor.Extensions;
+using MudBlazor.Services;
+using MudBlazor.Utilities;
+using CategoryAttribute = MudBlazor.CategoryAttribute;
+using Color = MudBlazor.Color;
+using Size = MudBlazor.Size;
+
+namespace MudExtensions
+{
+	public partial class MudRadioButton<T> : MudComponentBase, IDisposable
+	{
+		[CascadingParameter(Name = "RightToLeft")] public bool RightToLeft { get; set; }
+
+		protected string Classname =>
+		new CssBuilder("mud-radio-button")
+			.AddClass($"mud-disabled", IsDisabled)
+			.AddClass($"mud-readonly", MudRadioButtonGroup?.GetReadOnlyState())
+			.AddClass($"mud-radio-button-content-placement-{ConvertPlacement(Placement).ToDescriptionString()}")
+			.AddClass(Class)
+			.AddClass("d-flex flex-grow-1")
+			.Build();
+
+		protected string ButtonClassname =>
+		new CssBuilder("mud-button-root")
+			.AddClass($"mud-ripple mud-ripple-radio", !DisableRipple && !Disabled && !(MudRadioButtonGroup?.GetDisabledState() ?? false) && !(MudRadioButtonGroup?.GetReadOnlyState() ?? false))
+			.AddClass($"mud-{Color.ToDescriptionString()}-text hover:mud-{Color.ToDescriptionString()}-hover", UnCheckedColor == null || (UnCheckedColor != null && Checked == true))
+			.AddClass($"mud-{UnCheckedColor?.ToDescriptionString()}-text hover:mud-{UnCheckedColor?.ToDescriptionString()}-hover", UnCheckedColor != null && Checked == false)
+			.AddClass($"mud-radio-button-dense", Dense)
+			.AddClass($"mud-disabled", IsDisabled)
+			.AddClass($"mud-readonly", MudRadioButtonGroup?.GetReadOnlyState())
+			.AddClass($"mud-checked", Checked)
+			.AddClass("mud-error-text", MudRadioButtonGroup?.HasErrors)
+			.AddClass("d-flex flex-grow-1")
+			.Build();
+
+		protected string ChildSpanClassName =>
+		new CssBuilder("mud-radio-button-content mud-typography mud-typography-body1")
+			.AddClass("mud-error-text", MudRadioButtonGroup.HasErrors)
+			.Build();
+
+		private IMudRadioButtonGroup _parent;
+
+		/// <summary>
+		/// The parent Radio Group
+		/// </summary>
+		[CascadingParameter]
+		internal IMudRadioButtonGroup IMudRadioButtonGroup
+		{
+			get => _parent;
+			set
+			{
+				_parent = value;
+				if (_parent == null)
+					return;
+				_parent.CheckGenericTypeMatch(this);
+			}
+		}
+
+		internal MudRadioButtonGroup<T> MudRadioButtonGroup => (MudRadioButtonGroup<T>)IMudRadioButtonGroup;
+
+		private Placement ConvertPlacement(Placement placement)
+		{
+			return placement switch
+			{
+				Placement.Left => RightToLeft ? Placement.End : Placement.Start,
+				Placement.Right => RightToLeft ? Placement.Start : Placement.End,
+				_ => placement
+			};
+		}
+
+		/// <summary>
+		/// The color of the component. It supports the theme colors.
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.Radio.Appearance)]
+		public Color Color { get; set; } = Color.Default;
+
+		/// <summary>
+		/// The base color of the component in its none active/unchecked state. It supports the theme colors.
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.Radio.Appearance)]
+		public Color? UnCheckedColor { get; set; } = null;
+
+		/// <summary>
+		/// The position of the child content.
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.Radio.Behavior)]
+		public Placement Placement { get; set; } = Placement.End;
+
+		/// <summary>
+		/// The value to associate to the button.
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.Radio.Behavior)]
+		public T Option { get; set; }
+
+		/// <summary>
+		/// If true, compact padding will be applied.
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.Radio.Appearance)]
+		public bool Dense { get; set; }
+
+		/// <summary>
+		/// The Size of the component.
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.Radio.Appearance)]
+		public Size Size { get; set; } = Size.Medium;
+
+		/// <summary>
+		/// If true, disables ripple effect.
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.Radio.Appearance)]
+		public bool DisableRipple { get; set; }
+
+		/// <summary>
+		/// If true, the button will be disabled.
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.Radio.Behavior)]
+		public bool Disabled { get; set; }
+		private bool IsDisabled => Disabled || (MudRadioButtonGroup?.GetDisabledState() ?? false);
+
+		/// <summary>
+		/// Child content of component.
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.Radio.Behavior)]
+		public RenderFragment ChildContent { get; set; }
+
+		internal bool Checked { get; private set; }
+
+		internal void SetChecked(bool value)
+		{
+			if (Checked != value)
+			{
+				Checked = value;
+				StateHasChanged();
+			}
+		}
+
+		public void Select()
+		{
+			MudRadioButtonGroup?.SetSelectedRadioAsync(this).AndForget();
+		}
+
+		internal Task OnClick()
+		{
+			if (IsDisabled || (MudRadioButtonGroup?.GetReadOnlyState() ?? false))
+				return Task.CompletedTask;
+			if (MudRadioButtonGroup != null)
+				return MudRadioButtonGroup.SetSelectedRadioAsync(this);
+
+			return Task.CompletedTask;
+		}
+
+		protected internal async Task HandleKeyDownAsync(KeyboardEventArgs keyboardEventArgs)
+		{
+			if (IsDisabled || (MudRadioButtonGroup?.GetReadOnlyState() ?? false))
+				return;
+			switch (keyboardEventArgs.Key)
+			{
+				case "Enter":
+				case "NumpadEnter":
+				case " ":
+					Select();
+					break;
+				case "Backspace":
+					if (MudRadioButtonGroup is not null)
+					{
+						await MudRadioButtonGroup.ResetAsync();
+					}
+
+					break;
+			}
+		}
+
+		protected override async Task OnInitializedAsync()
+		{
+			await base.OnInitializedAsync();
+
+			if (MudRadioButtonGroup != null)
+				await MudRadioButtonGroup.RegisterRadioAsync(this);
+		}
+
+		public void Dispose()
+		{
+			MudRadioButtonGroup?.UnregisterRadio(this);
+			_keyInterceptor?.Dispose();
+		}
+
+		private IKeyInterceptor _keyInterceptor;
+		[Inject] private IKeyInterceptorFactory _keyInterceptorFactory { get; set; }
+
+		private readonly string _elementId = "radio" + Guid.NewGuid().ToString()[..8];
+
+		protected override async Task OnAfterRenderAsync(bool firstRender)
+		{
+			if (firstRender)
+			{
+				_keyInterceptor = _keyInterceptorFactory.Create();
+				await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
+				{
+					TargetClass = "mud-button-root",
+					Keys = {
+						new KeyOptions { Key=" ", PreventDown = "key+none", PreventUp = "key+none" }, // prevent scrolling page
+                        new KeyOptions { Key="Enter", PreventDown = "key+none" },
+						new KeyOptions { Key="NumpadEnter", PreventDown = "key+none" },
+						new KeyOptions { Key="Backspace", PreventDown = "key+none" },
+					},
+				});
+			}
+
+			await base.OnAfterRenderAsync(firstRender);
+		}
+	}
+}

--- a/CodeBeam.MudBlazor.Extensions/Components/RadioButton/MudRadioButtonGroup.razor
+++ b/CodeBeam.MudBlazor.Extensions/Components/RadioButton/MudRadioButtonGroup.razor
@@ -1,0 +1,13 @@
+﻿@namespace MudExtensions
+@typeparam T
+@inherits MudFormComponent<T, T>
+
+<MudInputControl Class="@Classname" Style="@Style" Error="@HasErrors" ErrorText="@GetErrorText()" Required="@Required">
+    <InputContent>
+        <CascadingValue Value="@((IMudRadioButtonGroup)this)" IsFixed="false">
+            <div role="radiogroup" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle">
+                @ChildContent
+            </div>
+        </CascadingValue>
+    </InputContent>
+</MudInputControl>

--- a/CodeBeam.MudBlazor.Extensions/Components/RadioButton/MudRadioButtonGroup.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/RadioButton/MudRadioButtonGroup.razor.cs
@@ -1,0 +1,165 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using MudBlazor.Utilities;
+using MudBlazor.Utilities.Exceptions;
+using CategoryAttribute = MudBlazor.CategoryAttribute;
+
+namespace MudExtensions
+{
+	public partial class MudRadioButtonGroup<T> : MudFormComponent<T, T>, IMudRadioButtonGroup
+	{
+		public MudRadioButtonGroup() : base(new MudBlazor.Converter<T, T>()) { }
+
+		private MudRadioButton<T> _selectedRadio;
+
+		private readonly HashSet<MudRadioButton<T>> _radios = new();
+
+		protected string Classname =>
+		new CssBuilder("mud-input-control-boolean-input")
+			.AddClass(Class)
+			.AddClass("d-flex")
+			.AddClass("flex-grow-1")
+			.Build();
+
+		private string GetInputClass() =>
+		new CssBuilder("mud-radio-button-group")
+			.AddClass(InputClass)
+			.AddClass("d-flex")
+			.AddClass("flex-grow-1")
+			.Build();
+
+		/// <summary>
+		/// User class names for the input, separated by space
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.Radio.Appearance)]
+		public string InputClass { get; set; }
+
+		/// <summary>
+		/// User style definitions for the input
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.Radio.Appearance)]
+		public string InputStyle { get; set; }
+
+		[Parameter]
+		[Category(CategoryTypes.Radio.Behavior)]
+		public RenderFragment ChildContent { get; set; }
+
+		[Parameter]
+		[Category(CategoryTypes.Radio.Behavior)]
+		public string Name { get; set; } = Guid.NewGuid().ToString();
+
+		public void CheckGenericTypeMatch(object select_item)
+		{
+			var itemT = select_item.GetType().GenericTypeArguments[0];
+			if (itemT != typeof(T))
+				throw new GenericTypeMismatchException("MudRadioButtonGroup", "MudRadio", typeof(T), itemT);
+		}
+
+		/// <summary>
+		/// If true, the input will be disabled.
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.FormComponent.Behavior)]
+		public bool Disabled { get; set; }
+		[CascadingParameter(Name = "ParentDisabled")] private bool ParentDisabled { get; set; }
+		internal bool GetDisabledState() => Disabled || ParentDisabled; //internal because the MudRadio reads this value directly
+
+		/// <summary>
+		/// If true, the input will be read-only.
+		/// </summary>
+		[Parameter]
+		[Category(CategoryTypes.FormComponent.Behavior)]
+		public bool ReadOnly { get; set; }
+		[CascadingParameter(Name = "ParentReadOnly")] private bool ParentReadOnly { get; set; }
+		internal bool GetReadOnlyState() => ReadOnly || ParentReadOnly; //internal because the MudRadio reads this value directly
+
+		[Parameter]
+		[Category(CategoryTypes.Radio.Data)]
+		public T SelectedOption
+		{
+			get => _value;
+			set => SetSelectedOptionAsync(value, true).AndForget();
+		}
+
+		protected async Task SetSelectedOptionAsync(T option, bool updateRadio)
+		{
+			if (!OptionEquals(_value, option))
+			{
+				_value = option;
+
+				if (updateRadio)
+					await SetSelectedRadioAsync(_radios.FirstOrDefault(r => OptionEquals(r.Option, _value)), false);
+
+				await SelectedOptionChanged.InvokeAsync(_value);
+
+				await BeginValidateAsync();
+				FieldChanged(_value);
+			}
+		}
+
+		[Parameter]
+		public EventCallback<T> SelectedOptionChanged { get; set; }
+
+		internal Task SetSelectedRadioAsync(MudRadioButton<T> radio)
+		{
+			Touched = true;
+			return SetSelectedRadioAsync(radio, true);
+		}
+
+		protected async Task SetSelectedRadioAsync(MudRadioButton<T> radio, bool updateOption)
+		{
+			// Select a new radio or toggle the one that was already selected.
+			_selectedRadio = _selectedRadio == radio ? null : radio;
+
+			foreach (var item in _radios.ToArray())
+				item.SetChecked(item == _selectedRadio);
+
+			if (updateOption)
+				await SetSelectedOptionAsync(GetOptionOrDefault(_selectedRadio), false);
+		}
+
+		internal Task RegisterRadioAsync(MudRadioButton<T> radio)
+		{
+			_radios.Add(radio);
+
+			if (_selectedRadio == null)
+			{
+				if (OptionEquals(radio.Option, _value))
+					return SetSelectedRadioAsync(radio, false);
+			}
+
+			return Task.CompletedTask;
+		}
+
+		internal void UnregisterRadio(MudRadioButton<T> radio)
+		{
+			_radios.Remove(radio);
+
+			if (_selectedRadio == radio)
+				_selectedRadio = null;
+		}
+
+		protected override Task ResetValueAsync()
+		{
+			if (_selectedRadio != null)
+			{
+				_selectedRadio.SetChecked(false);
+				_selectedRadio = null;
+			}
+
+			return base.ResetValueAsync();
+		}
+
+		private static T GetOptionOrDefault(MudRadioButton<T> radio)
+		{
+			return radio != null ? radio.Option : default;
+		}
+
+		private static bool OptionEquals(T option1, T option2)
+		{
+			return EqualityComparer<T>.Default.Equals(option1, option2);
+		}
+	}
+}

--- a/CodeBeam.MudBlazor.Extensions/Components/RadioButton/MudRadioButtonGroup.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/RadioButton/MudRadioButtonGroup.razor.cs
@@ -141,17 +141,6 @@ namespace MudExtensions
 				_selectedRadio = null;
 		}
 
-		protected override Task ResetValueAsync()
-		{
-			if (_selectedRadio != null)
-			{
-				_selectedRadio.SetChecked(false);
-				_selectedRadio = null;
-			}
-
-			return base.ResetValueAsync();
-		}
-
 		private static T GetOptionOrDefault(MudRadioButton<T> radio)
 		{
 			return radio != null ? radio.Option : default;


### PR DESCRIPTION
I made this prototype for #232 based on the `MudRadio*` code. It's rough around the edges (styling should be in its own CSS etc) but partly functional. Wanted to share anyway to see if you thought I was on the right track!

```razor
<div class="d-flex flex-grow-1">
	<MudRadioButtonGroup @bind-SelectedOption="DataPoint.ScaleIndex">
		@foreach (var i in Enumerable.Range(1, 5))
		{
			<MudRadioButton T="int" Color="Color.Primary">@i</MudRadioButton>
		}
	</MudRadioButtonGroup>
</div>
```

![Animation](https://github.com/CodeBeamOrg/CodeBeam.MudBlazor.Extensions/assets/7112040/d5e2ac91-d10a-4271-8312-79dbd766ba7c)

I made it for an app, so it's more to my spec than what was suggested in the comments. No hard feelings if you'd rather take it in a different direction!