### PR TITLE
Fixed combobox multiselection clear

### DIFF
--- a/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor.cs
@@ -1148,6 +1148,7 @@ namespace MudExtensions
             _selectedValues.Clear();
             DeselectAllItems();
             await BeginValidateAsync();
+            await ForceUpdateItems();
             StateHasChanged();
             await SelectedValuesChanged.InvokeAsync(new HashSet<T>(SelectedValues, _comparer));
             await OnClearButtonClick.InvokeAsync(e);


### PR DESCRIPTION
In ComboBox with MultiSelection the value are not cleared correctly when pressing the clear button. The value are updated only the second time you press on the combobox again.

This should fix it.