### PR TITLE
MudSignaturePad - Sync Value to be empty when the Clear button is fired

### DIFF
--- a/CodeBeam.MudBlazor.Extensions/Components/SignaturePad/MudSignaturePad.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/SignaturePad/MudSignaturePad.razor.cs
@@ -70,7 +70,7 @@ public partial class MudSignaturePad : IAsyncDisposable
     [Parameter] public bool ShowLineJoinStyle { get; set; } = true;
     [Parameter] public bool ShowLineCapStyle { get; set; } = true;
     [Parameter] public bool Dense { get; set; }
-    [Parameter] public Variant Variant  { get; set; }
+    [Parameter] public Variant Variant { get; set; }
     [Parameter] public Color Color { get; set; }
     [Parameter] public RenderFragment ToolbarContent { get; set; }
 
@@ -96,6 +96,8 @@ public partial class MudSignaturePad : IAsyncDisposable
 
     async Task ClearPad()
     {
+        Value = Array.Empty<byte>();
+        await ValueChanged.InvokeAsync(Value);
         await JsRuntime.InvokeVoidAsync("mudSignaturePad.clearPad", _reference);
     }
 

--- a/CodeBeam.MudBlazor.Extensions/Components/SignaturePad/MudSignaturePad.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/SignaturePad/MudSignaturePad.razor.cs
@@ -96,8 +96,7 @@ public partial class MudSignaturePad : IAsyncDisposable
 
     async Task ClearPad()
     {
-        Value = Array.Empty<byte>();
-        await ValueChanged.InvokeAsync(Value);
+        await ValueChanged.InvokeAsync(Array.Empty<byte>());
         await JsRuntime.InvokeVoidAsync("mudSignaturePad.clearPad", _reference);
     }
 


### PR DESCRIPTION
When clicking the Clear button on the MudSignaturePad the Value param is never updated/emptied even though the canvas appears blank, meaning that if you draw, then clear the canvas, then save/download, instead of a blank canvas you will get the state before the clear.

This update just empties the Value param and fires the ValueChanged event to ensure anything hooked in will be synched too