### PR TITLE
Fix for none zero min value in Range Slider

### DIFF
--- a/CodeBeam.MudBlazor.Extensions/Components/RangeSlider/MudRangeSlider.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/RangeSlider/MudRangeSlider.razor.cs
@@ -344,7 +344,7 @@ namespace MudExtensions
 
             if (Range)
             {
-                value = (Convert.ToDouble(UpperValue) - Convert.ToDouble(Value));
+                value = (Convert.ToDouble(UpperValue) + min - Convert.ToDouble(Value));
             }
 
             var result = 100.0 * (value - min) / (max - min);


### PR DESCRIPTION
There was a problem in Range Slider when you set the min value to something bigger then zero. This small fix solves that problem. 