### PR TITLE
SelectExtended: Add the ability to display additional content

### DIFF
--- a/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor
+++ b/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor
@@ -103,9 +103,9 @@
                     </MudInputExtended>
 
                     <MudPopover Open="@_isOpen" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="@RelativeWidth">
-                        @if (AdditionalContent != null)
+                        @if (StaticContent != null)
                         {
-                            @AdditionalContent(this)
+                            @StaticContent(this)
                         }
 
                         <CascadingValue Value="@this" IsFixed="true">

--- a/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor
+++ b/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor
@@ -103,7 +103,7 @@
                     </MudInputExtended>
 
                     <MudPopover Open="@_isOpen" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="@RelativeWidth">
-                        @if (StaticContent != null)
+                        @if (StaticContent != null && !ShowStaticContentAtEnd)
                         {
                             @StaticContent(this)
                         }
@@ -118,6 +118,11 @@
                                 @ChildContent
                             </MudListExtended>
                         </CascadingValue>
+
+                        @if (StaticContent != null && ShowStaticContentAtEnd)
+                        {
+                            @StaticContent(this)
+                        }
                     </MudPopover>
                 </InputContent>
             </MudInputControl>

--- a/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor
+++ b/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor
@@ -94,15 +94,20 @@
                                     }
                                 }
                             </div>
-                            
+
                         </DataVisualiser>
 
                         <ChildContent>
-                            
+
                         </ChildContent>
                     </MudInputExtended>
 
-				<MudPopover Open="@_isOpen" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="@RelativeWidth">
+                    <MudPopover Open="@_isOpen" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="@RelativeWidth">
+                        @if (AdditionalContent != null)
+                        {
+                            @AdditionalContent(this)
+                        }
+
                         <CascadingValue Value="@this" IsFixed="true">
                             <MudListExtended @ref="@_list" T="T" @bind-SelectedValue="@Value" Style="@($"overflow-y:auto; max-height: {MaxHeight}px")" @bind-SelectedValues="@SelectedValues" @bind-SelectedItem="@SelectedListItem" @bind-SelectedItems="@SelectedListItems"
                                              Clickable="true" Color="@Color" Dense="@Dense" ItemCollection="@ItemCollection" Virtualize="@Virtualize" Padding="@EnablePopoverPadding" DisableSelectedItemStyle="@EnableSelectedItemStyle"

--- a/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
@@ -115,6 +115,13 @@ namespace MudExtensions
         public RenderFragment<MudSelectExtended<T>>? StaticContent { get; set; }
 
         /// <summary>
+        /// Whether to show <see cref="StaticContent"/> at the bottom of the popover.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public bool ShowStaticContentAtEnd { get; set; }
+
+        /// <summary>
         /// Optional presentation template for items
         /// </summary>
         [Parameter]

--- a/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
@@ -112,7 +112,7 @@ namespace MudExtensions
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.Appearance)]
-        public RenderFragment<MudSelectExtended<T>>? AdditionalContent { get; set; }
+        public RenderFragment<MudSelectExtended<T>>? StaticContent { get; set; }
 
         /// <summary>
         /// Optional presentation template for items

--- a/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
@@ -108,6 +108,13 @@ namespace MudExtensions
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
+        /// Optional additional content to display above the list within the popover.
+        /// </summary>
+        [Parameter]
+        [Category(CategoryTypes.FormComponent.Appearance)]
+        public RenderFragment<MudSelectExtended<T>>? AdditionalContent { get; set; }
+
+        /// <summary>
         /// Optional presentation template for items
         /// </summary>
         [Parameter]


### PR DESCRIPTION
This pull request is the same as #449. I had created it from the wrong branch originally.

SelectExtended: Add the ability to display additional content within the popover above the list

This allows adding content to the select popover that is not part of the actual list. Useful for adding validation or help messages.