### PR TITLE
Add Escape key support to the SearchBox of the MudSelectExtended

### DIFF
--- a/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListExtended.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListExtended.razor.cs
@@ -936,6 +936,13 @@ namespace MudExtensions
                         await MudSelectExtended.FocusAsync();
                     }
                     break;
+                 case "Escape":                    
+                    if (MudSelectExtended != null && MultiSelection == false)
+                    {
+                        await MudSelectExtended.CloseMenu();
+                        await MudSelectExtended.FocusAsync();
+                    }
+                    break;
                 case "Tab":
                     await Task.Delay(10);
                     await ActiveFirstItem();


### PR DESCRIPTION
The ESC key closes the popup except if we have focus inside the SearchBox. We would also like the popup to close with we hit the ESC while focus is within the SearchBox