### PR TITLE
Made MudSelectExtended IsOpen flag public

### DIFF
--- a/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor
+++ b/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor
@@ -102,7 +102,7 @@
                         </ChildContent>
                     </MudInputExtended>
 
-                    <MudPopover Open="@_isOpen" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="@RelativeWidth">
+                    <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="@RelativeWidth">
                         @if (StaticContent != null && !ShowStaticContentAtEnd)
                         {
                             @StaticContent(this)
@@ -155,4 +155,4 @@
 
 </CascadingValue>
 <!-- mousedown instead of click needed to close the menu before OnLostFocus runs -->
-<MudOverlay Visible="_isOpen" @onmousedown="@(() => CloseMenu())" LockScroll="@LockScroll" />
+<MudOverlay Visible="IsOpen" @onmousedown="@(() => CloseMenu())" LockScroll="@LockScroll" />

--- a/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor
+++ b/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor
@@ -102,7 +102,7 @@
                         </ChildContent>
                     </MudInputExtended>
 
-                    <MudPopover Open="@IsOpen" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="@RelativeWidth">
+                    <MudPopover Open="@_isOpen" MaxHeight="@MaxHeight" AnchorOrigin="@AnchorOrigin" TransformOrigin="@TransformOrigin" Class="@PopoverClass" RelativeWidth="@RelativeWidth">
                         @if (StaticContent != null && !ShowStaticContentAtEnd)
                         {
                             @StaticContent(this)
@@ -155,4 +155,4 @@
 
 </CascadingValue>
 <!-- mousedown instead of click needed to close the menu before OnLostFocus runs -->
-<MudOverlay Visible="IsOpen" @onmousedown="@(() => CloseMenu())" LockScroll="@LockScroll" />
+<MudOverlay Visible="_isOpen" @onmousedown="@(() => CloseMenu())" LockScroll="@LockScroll" />

--- a/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
@@ -49,9 +49,6 @@ namespace MudExtensions
         /// </summary>
         protected Dictionary<T, MudSelectItemExtended<T?>> _shadowLookup = new();
         private MudInputExtended<string> _elementReference = new();
-        /// <summary>
-        /// 
-        /// </summary>
         internal bool _isOpen;
         /// <summary>
         /// 

--- a/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
@@ -49,7 +49,10 @@ namespace MudExtensions
         /// </summary>
         protected Dictionary<T, MudSelectItemExtended<T?>> _shadowLookup = new();
         private MudInputExtended<string> _elementReference = new();
-        internal bool _isOpen;
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool IsOpen;
         /// <summary>
         /// 
         /// </summary>
@@ -847,7 +850,7 @@ namespace MudExtensions
             if (Disabled || ReadOnly)
                 return;
 
-            if (_list != null && _isOpen)
+            if (_list != null && IsOpen)
             {
                 await _list.HandleKeyDown(obj);
             }
@@ -862,7 +865,7 @@ namespace MudExtensions
                     {
                         await CloseMenu();
                     }
-                    else if (!_isOpen)
+                    else if (!IsOpen)
                     {
                         await OpenMenu();
                     }
@@ -872,7 +875,7 @@ namespace MudExtensions
                     {
                         await OpenMenu();
                     }
-                    else if (!_isOpen)
+                    else if (!IsOpen)
                     {
                         await OpenMenu();
                     }
@@ -887,7 +890,7 @@ namespace MudExtensions
                 case "NumpadEnter":
                     if (!MultiSelection)
                     {
-                        if (!_isOpen)
+                        if (!IsOpen)
                         {
                             await OpenMenu();
                         }
@@ -899,7 +902,7 @@ namespace MudExtensions
                     }
                     else
                     {
-                        if (!_isOpen)
+                        if (!IsOpen)
                         {
                             await OpenMenu();
                             break;
@@ -993,7 +996,7 @@ namespace MudExtensions
         {
             if (Disabled || ReadOnly)
                 return;
-            if (_isOpen)
+            if (IsOpen)
                 await CloseMenu();
             else
                 await OpenMenu();
@@ -1007,7 +1010,7 @@ namespace MudExtensions
         {
             if (Disabled || ReadOnly)
                 return;
-            _isOpen = true;
+            IsOpen = true;
             UpdateIcon();
             StateHasChanged();
 
@@ -1022,7 +1025,7 @@ namespace MudExtensions
         /// <returns></returns>
         public async Task CloseMenu()
         {
-            _isOpen = false;
+            IsOpen = false;
             UpdateIcon();
             StateHasChanged();
             //if (focusAgain == true)
@@ -1261,7 +1264,7 @@ namespace MudExtensions
         /// </summary>
         protected void UpdateIcon()
         {
-            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
+            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : IsOpen ? CloseIcon : OpenIcon;
         }
 
         /// <summary>

--- a/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
@@ -52,7 +52,7 @@ namespace MudExtensions
         /// <summary>
         /// 
         /// </summary>
-        public bool IsOpen;
+        internal bool _isOpen;
         /// <summary>
         /// 
         /// </summary>
@@ -850,7 +850,7 @@ namespace MudExtensions
             if (Disabled || ReadOnly)
                 return;
 
-            if (_list != null && IsOpen)
+            if (_list != null && _isOpen)
             {
                 await _list.HandleKeyDown(obj);
             }
@@ -865,7 +865,7 @@ namespace MudExtensions
                     {
                         await CloseMenu();
                     }
-                    else if (!IsOpen)
+                    else if (!_isOpen)
                     {
                         await OpenMenu();
                     }
@@ -875,7 +875,7 @@ namespace MudExtensions
                     {
                         await OpenMenu();
                     }
-                    else if (!IsOpen)
+                    else if (!_isOpen)
                     {
                         await OpenMenu();
                     }
@@ -890,7 +890,7 @@ namespace MudExtensions
                 case "NumpadEnter":
                     if (!MultiSelection)
                     {
-                        if (!IsOpen)
+                        if (!_isOpen)
                         {
                             await OpenMenu();
                         }
@@ -902,7 +902,7 @@ namespace MudExtensions
                     }
                     else
                     {
-                        if (!IsOpen)
+                        if (!_isOpen)
                         {
                             await OpenMenu();
                             break;
@@ -996,7 +996,7 @@ namespace MudExtensions
         {
             if (Disabled || ReadOnly)
                 return;
-            if (IsOpen)
+            if (_isOpen)
                 await CloseMenu();
             else
                 await OpenMenu();
@@ -1010,7 +1010,7 @@ namespace MudExtensions
         {
             if (Disabled || ReadOnly)
                 return;
-            IsOpen = true;
+            _isOpen = true;
             UpdateIcon();
             StateHasChanged();
 
@@ -1025,7 +1025,7 @@ namespace MudExtensions
         /// <returns></returns>
         public async Task CloseMenu()
         {
-            IsOpen = false;
+            _isOpen = false;
             UpdateIcon();
             StateHasChanged();
             //if (focusAgain == true)
@@ -1264,7 +1264,7 @@ namespace MudExtensions
         /// </summary>
         protected void UpdateIcon()
         {
-            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : IsOpen ? CloseIcon : OpenIcon;
+            _currentIcon = !string.IsNullOrWhiteSpace(AdornmentIcon) ? AdornmentIcon : _isOpen ? CloseIcon : OpenIcon;
         }
 
         /// <summary>
@@ -1307,6 +1307,15 @@ namespace MudExtensions
             //SelectedValues = SelectedValues.Where(x => Converter.Set(x)?.ToString() != chip.Value?.ToString());
             SelectedValues = SelectedValues.Where(x => x?.Equals(chip.Value) == false);
             await SelectedValuesChanged.InvokeAsync(SelectedValues);
+        }
+        
+        /// <summary>
+        /// returns the value of the internal property _isOpen 
+        /// </summary>
+        /// <returns></returns>
+        public bool GetOpenState()
+        {
+            return _isOpen;
         }
     }
 }


### PR DESCRIPTION
For discussion:

Made IsOpen property public in MudSelectExtended. This change allows external components or logic to determine whether the dropdown is currently open. It resolves the issue where OnOpen fires too late for a particular use-case (it fires after the content is rendered). By making IsOpen public, you can now directly check the dropdown's state and conditionally render components in the dropdown, ensuring it appears immediately when the dropdown opens.