### PR TITLE
MudJsonTreeView: Exposed "Root" as a Parameter for Setting JsonNode Directly

### DIFF
--- a/CodeBeam.MudBlazor.Extensions/Components/JsonTreeView/MudJsonTreeView.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/JsonTreeView/MudJsonTreeView.razor.cs
@@ -12,15 +12,31 @@ namespace MudExtensions;
 public partial class MudJsonTreeView : MudComponentBase
 {
     private string? _json;
+    private JsonNode? _root;
 
     /// <summary>
-    /// Gets or sets the JSON to be displayed.
+    /// The JSON to be displayed.
     /// </summary>
+    /// <remarks>
+    /// Use the <see cref="Root"/> parameter instead if you have a <see cref="JsonNode"/> available.
+    /// </remarks>
     [Parameter]
-    [EditorRequired]
     public string? Json 
     {
         get => _json;
+        set => SetJson(value);
+    }
+
+    /// <summary>
+    /// The root node of the JSON to display.
+    /// </summary>
+    /// <remarks>
+    /// Use the <see cref="Json"/> parameter instead if you only have JSON available as a string.
+    /// </remarks>
+    [Parameter]
+    public JsonNode? Root
+    {
+        get => _root;
         set => SetJson(value);
     }
 
@@ -31,20 +47,27 @@ public partial class MudJsonTreeView : MudComponentBase
     protected void SetJson(string? json)
     {
         _json = json;
-        Root = string.IsNullOrEmpty(_json) ? null : JsonNode.Parse(_json);
-        OnJsonChanged.InvokeAsync(_json);
+        _root = string.IsNullOrEmpty(_json) ? null : JsonNode.Parse(_json);
+        OnJsonChanged.InvokeAsync(Root);
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Sets the <see cref="Json"/> property and raises the <see cref="OnJsonChanged"/> event.
+    /// </summary>
+    /// <param name="json">The new JSON to use.</param>
+    protected void SetJson(JsonNode? json)
+    {
+        _json = json?.ToJsonString();
+        _root = json;
+        OnJsonChanged.InvokeAsync(Root);
         StateHasChanged();
     }
 
     /// <summary>
     /// Occurs when the JSON has changed.
     /// </summary>
-    public EventCallback<string> OnJsonChanged { get; set; }
-
-    /// <summary>
-    /// Gets or sets the root node of the JSON to display.
-    /// </summary>
-    public JsonNode? Root { get; set; }
+    public EventCallback<JsonNode> OnJsonChanged { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the tree contents are compacted.

--- a/CodeBeam.MudBlazor.Extensions/Components/JsonTreeView/MudJsonTreeViewNode.razor
+++ b/CodeBeam.MudBlazor.Extensions/Components/JsonTreeView/MudJsonTreeViewNode.razor
@@ -76,3 +76,48 @@ else if (Node is JsonArray)
         </MudTreeViewItem>
     }
 }
+else if (Node is JsonNode)
+{
+    var valueKind = Node.AsValue().GetValue<JsonElement>().ValueKind;
+    switch (valueKind)
+    {
+        case JsonValueKind.String:
+            var str = Node.AsValue().GetValue<string>();
+            @* Could be a date *@
+            if (DateTime.TryParse(str, out DateTime date))
+            {
+                <MudTreeViewItem T="string" Icon="@Icons.Material.Filled.DateRange" EndText="@date.ToString()"></MudTreeViewItem>
+            }
+            @* Could be a GUID *@
+            else if (Guid.TryParse(str, out Guid guid))
+            {
+                <MudTreeViewItem T="string" Icon="@Icons.Material.Filled.Key" EndText="@str.ToUpperInvariant()"></MudTreeViewItem>
+            }
+            @* Fall back to string *@
+            else
+            {
+                <MudTreeViewItem T="string" Icon="@Icons.Material.Filled.TextSnippet" EndText="@str"></MudTreeViewItem>
+            }
+            break;
+        case JsonValueKind.Number:
+            JsonValue jsonVal = Node.AsValue();
+            string endText = string.Empty;
+            @* We try for int first, because an int can always be converted to double but not the other way around*@
+            if (jsonVal.TryGetValue<int>(out int intVal))
+            {
+                endText = intVal.ToString();
+            }
+            else if (jsonVal.TryGetValue<double>(out double doubleVal))
+            {
+                endText = doubleVal.ToString();
+            }
+            <MudTreeViewItem T="string" Icon="@Icons.Material.Filled.Numbers" EndText="@endText"></MudTreeViewItem>
+            break;
+        case JsonValueKind.True:
+            <MudTreeViewItem T="string" Icon="@Icons.Material.Filled.CheckBox" EndText="true"></MudTreeViewItem>
+            break;
+        case JsonValueKind.False:
+            <MudTreeViewItem T="string" Icon="@Icons.Material.Filled.CheckBoxOutlineBlank" EndText="false"></MudTreeViewItem>
+            break;
+    }
+}


### PR DESCRIPTION
This update adds the `[Parameter]` attribute to the `Root` property to allow users to set JSON nodes directly when they have a `JsonNode` already.  Also, a bug was fixed for `JsonArray` values not displaying properly.

Fixes #451 