### PR TITLE
Use KeyInterceptorService

### DIFF
--- a/CodeBeam.MudBlazor.Extensions.Docs/CodeBeam.MudBlazor.Extensions.Docs.csproj
+++ b/CodeBeam.MudBlazor.Extensions.Docs/CodeBeam.MudBlazor.Extensions.Docs.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.*" />
-    <PackageReference Include="MudBlazor" Version="7.3.0" />
+    <PackageReference Include="MudBlazor" Version="7.12.1" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/CodeBeam.MudBlazor.Extensions.UnitTests/Mocks/MockKeyInterceptor.cs
+++ b/CodeBeam.MudBlazor.Extensions.UnitTests/Mocks/MockKeyInterceptor.cs
@@ -1,4 +1,6 @@
-﻿using MudBlazor.Services;
+﻿using Microsoft.AspNetCore.Components.Web;
+using MudBlazor;
+using MudBlazor.Services;
 
 namespace MudExtensions.UnitTests.Mocks
 {
@@ -21,7 +23,7 @@ namespace MudExtensions.UnitTests.Mocks
         public IKeyInterceptor Create() => _interceptorService ?? new MockKeyInterceptorService();
     }
 
-    public class MockKeyInterceptorService : IKeyInterceptor
+    public class MockKeyInterceptorService : IKeyInterceptor, IKeyInterceptorService
     {
         public void Dispose()
         {
@@ -45,5 +47,23 @@ namespace MudExtensions.UnitTests.Mocks
 
         public event KeyboardEvent? KeyDown;
         public event KeyboardEvent? KeyUp;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public Task SubscribeAsync(IKeyInterceptorObserver observer, KeyInterceptorOptions options) => Task.CompletedTask;
+
+        public Task SubscribeAsync(string elementId, KeyInterceptorOptions options, IKeyDownObserver? keyDown = null, IKeyUpObserver? keyUp = null) => Task.CompletedTask;
+
+        public Task SubscribeAsync(string elementId, KeyInterceptorOptions options, Action<KeyboardEventArgs>? keyDown = null, Action<KeyboardEventArgs>? keyUp = null) => Task.CompletedTask;
+
+        public Task SubscribeAsync(string elementId, KeyInterceptorOptions options, Func<KeyboardEventArgs, Task>? keyDown = null, Func<KeyboardEventArgs, Task>? keyUp = null) => Task.CompletedTask;
+
+        public Task UpdateKeyAsync(IKeyInterceptorObserver observer, KeyOptions option) => Task.CompletedTask;
+
+        public Task UpdateKeyAsync(string elementId, KeyOptions option) => Task.CompletedTask;
+
+        public Task UnsubscribeAsync(IKeyInterceptorObserver observer) => Task.CompletedTask;
+
+        public Task UnsubscribeAsync(string elementId) => Task.CompletedTask;
     }
 }

--- a/CodeBeam.MudBlazor.Extensions/CodeBeam.MudBlazor.Extensions.csproj
+++ b/CodeBeam.MudBlazor.Extensions/CodeBeam.MudBlazor.Extensions.csproj
@@ -32,7 +32,7 @@
 	<ItemGroup>
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
 		<PackageReference Include="CsvHelper" Version="31.0.3" />
-		<PackageReference Include="MudBlazor" Version="7.3.0" />
+		<PackageReference Include="MudBlazor" Version="7.12.1" />
 		<PackageReference Include="ZXing.Net" Version="0.16.9" />
 	</ItemGroup>
 

--- a/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor
+++ b/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor
@@ -4,7 +4,7 @@
 @using MudExtensions.Services
 @typeparam T
 @inherits MudBaseInputExtended<T>
-@inject IKeyInterceptorFactory KeyInterceptorFactory
+@inject IKeyInterceptorService KeyInterceptorService
 @inject IScrollManagerExtended ScrollManagerExtended
 
 <CascadingValue Name="Standalone" Value="false" IsFixed="true">

--- a/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor.cs
@@ -38,7 +38,7 @@ namespace MudExtensions
         private readonly string? multiSelectionText;
         static readonly KeyInterceptorOptions _keyInterceptorOptions = new()
         {
-            //EnableLogging = true,
+            EnableLogging = true,
             TargetClass = "mud-input-control",
             Keys =
             {
@@ -850,7 +850,7 @@ namespace MudExtensions
             if (firstRender)
             {
                 // TODO: Use Task for HandleKeyDown / HandleKeyDown
-                await KeyInterceptorService.SubscribeAsync(_elementId, _keyInterceptorOptions, keyDown: HandleKeyDown, keyUp: HandleKeyDown);
+                await KeyInterceptorService.SubscribeAsync(_elementId, _keyInterceptorOptions, keyDown: HandleKeyDown, keyUp: HandleKeyUp);
                 await UpdateDataVisualiserTextAsync();
                 _firstRendered = true;
                 StateHasChanged();
@@ -1162,7 +1162,7 @@ namespace MudExtensions
             UpdateIcon();
 
             // Disable escape propagation: if ComboBox menu is open, only the ComboBox popover should close and underlying components should not handle escape key.
-            await KeyInterceptorService.UpdateKeyAsync(_elementId, new KeyOptions("Escape", stopDown: "Key+none"));
+            await KeyInterceptorService.UpdateKeyAsync(_elementId, new KeyOptions("Escape", stopDown: "key+none"));
 
             _allSelected = GetAllSelectedState();
 

--- a/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor.cs
@@ -36,7 +36,6 @@ namespace MudExtensions
 
         internal string? _searchString { get; set; }
         private readonly string? multiSelectionText;
-        private IKeyInterceptor? _keyInterceptor;
         static readonly KeyInterceptorOptions _keyInterceptorOptions = new()
         {
             //EnableLogging = true,
@@ -850,10 +849,8 @@ namespace MudExtensions
 
             if (firstRender)
             {
-                _keyInterceptor = KeyInterceptorFactory.Create();
-                await _keyInterceptor.Connect(_elementId, _keyInterceptorOptions);
-                _keyInterceptor.KeyDown += HandleKeyDown;
-                _keyInterceptor.KeyUp += HandleKeyUp;
+                // TODO: Use Task for HandleKeyDown / HandleKeyDown
+                await KeyInterceptorService.SubscribeAsync(_elementId, _keyInterceptorOptions, keyDown: HandleKeyDown, keyUp: HandleKeyDown);
                 await UpdateDataVisualiserTextAsync();
                 _firstRendered = true;
                 StateHasChanged();
@@ -872,12 +869,10 @@ namespace MudExtensions
 
             if (disposing)
             {
-                if (_keyInterceptor != null)
+                if (IsJSRuntimeAvailable)
                 {
-                    _keyInterceptor.KeyDown -= HandleKeyDown;
-                    _keyInterceptor.KeyUp -= HandleKeyUp;
-                    _keyInterceptor.Dispose();
-                    _keyInterceptor = null;
+                    // TODO: Switch to IAsyncDisposable
+                    KeyInterceptorService.UnsubscribeAsync(_elementId).CatchAndLog();
                 }
 
                 Items.Clear();
@@ -1167,10 +1162,7 @@ namespace MudExtensions
             UpdateIcon();
 
             // Disable escape propagation: if ComboBox menu is open, only the ComboBox popover should close and underlying components should not handle escape key.
-            if (_keyInterceptor != null)
-            {
-                await _keyInterceptor.UpdateKey(new() { Key = "Escape", StopDown = "Key+none" });
-            }
+            await KeyInterceptorService.UpdateKeyAsync(_elementId, new KeyOptions("Escape", stopDown: "Key+none"));
 
             _allSelected = GetAllSelectedState();
 
@@ -1211,10 +1203,7 @@ namespace MudExtensions
                 _searchString = null;
 
             // Enable escape propagation: The ComboBox popover was closed, no underlying components are allowed to handle escape key.
-            if (_keyInterceptor != null)
-            {
-                await _keyInterceptor.UpdateKey(new() { Key = "Escape", StopDown = "none" });
-            }
+            await KeyInterceptorService.UpdateKeyAsync(_elementId, new KeyOptions("Escape", stopDown: "none"));
 
             await OnClose.InvokeAsync();
         }

--- a/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListExtended.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListExtended.razor.cs
@@ -16,7 +16,7 @@ namespace MudExtensions
     {
         #region Parameters, Fields, Injected Services
 
-        [Inject] IKeyInterceptorFactory? KeyInterceptorFactory { get; set; }
+        [Inject] private IKeyInterceptorService KeyInterceptorService { get; set; } = null!;
         [Inject] IScrollManagerExtended? ScrollManagerExtended { get; set; }
 
         // Fields used in more than one place (or protected and internal ones) are shown here.
@@ -757,9 +757,8 @@ namespace MudExtensions
             if (firstRender)
             {
                 _firstRendered = false;
-                _keyInterceptor = KeyInterceptorFactory?.Create();
 
-                await _keyInterceptor.Connect(_elementId, new KeyInterceptorOptions()
+                await KeyInterceptorService.SubscribeAsync(_elementId, new KeyInterceptorOptions
                 {
                     //EnableLogging = true,
                     TargetClass = "mud-list-item-extended",
@@ -776,7 +775,7 @@ namespace MudExtensions
                         new KeyOptions { Key="A", PreventDown = "key+ctrl" }, // select all items instead of all page text
                         new KeyOptions { Key="/./", SubscribeDown = true, SubscribeUp = true }, // for our users
                     },
-                });
+                }, KeyObserver.KeyDownIgnore(), KeyObserver.KeyUpIgnore());
 
                 if (MudSelectExtended == null && MudAutocomplete == null)
                 {


### PR DESCRIPTION
The `IKeyInterceptor` / `KeyInterceptorFactory` is obsolete and removed in v8.
I left some TODOs.
It's better to make all your `HandleKeyDown` / `HandleKeyUp` to be `Task` as for now it would be breaking change for some as it's protected. Also it would be better to use `IAsyncDisposable` instead of `IDisposable` for this components.