### PR TITLE
MudSelectExtended: Fix disabled and readonly state when parent is disabled or readonly

### DIFF
--- a/CodeBeam.MudBlazor.Extensions.UnitTests.Viewer/TestComponents/SelectExtended/DisabledParentSelectTest.razor
+++ b/CodeBeam.MudBlazor.Extensions.UnitTests.Viewer/TestComponents/SelectExtended/DisabledParentSelectTest.razor
@@ -1,0 +1,13 @@
+@namespace MudExtensions.UnitTests.TestComponents
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudForm Disabled="true">
+    <MudSelectExtended T="string" @bind-Value="value" PopoverClass="select-popover-class">
+        <MudSelectItemExtended Value="@("1")" />
+        <MudSelectItemExtended Value="@("2")" />
+    </MudSelectExtended>
+</MudForm>
+
+@code {
+    string? value = null;
+}

--- a/CodeBeam.MudBlazor.Extensions.UnitTests.Viewer/TestComponents/SelectExtended/SelectTest1.razor
+++ b/CodeBeam.MudBlazor.Extensions.UnitTests.Viewer/TestComponents/SelectExtended/SelectTest1.razor
@@ -1,7 +1,7 @@
 ﻿@namespace MudExtensions.UnitTests.TestComponents
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudSelectExtended T="string" @bind-Value="value" PopoverClass="select-popover-class" onfocus="Focused" OnBlur="Blurred">
+<MudSelectExtended T="string" @bind-Value="value" PopoverClass="select-popover-class" Disabled="@Disabled" onfocus="Focused" OnBlur="Blurred">
     <MudSelectItemExtended Value="@("1")"/>
     <MudSelectItemExtended Value="@("2")"/>
     <MudSelectItemExtended Value="@("3")"/>
@@ -11,18 +11,21 @@
 <MudSwitch @bind-Value="@_focused" />
 
 @code {
-	public static string __description__ = "Click should open the Menu and selecting a value should update the bindable value.";
+    public static string __description__ = "Click should open the Menu and selecting a value should update the bindable value.";
 
-	string? value = null;
-	bool _focused = false;
+    [Parameter]
+    public bool Disabled { get; set; }
 
-	private void Focused()
-	{
-		_focused = true;
-	}
+    string? value = null;
+    bool _focused = false;
 
-	private void Blurred()
-	{
-		_focused = false;
-	}
+    private void Focused()
+    {
+        _focused = true;
+    }
+
+    private void Blurred()
+    {
+        _focused = false;
+    }
 }

--- a/CodeBeam.MudBlazor.Extensions.UnitTests/Components/SelectExtendedTests.cs
+++ b/CodeBeam.MudBlazor.Extensions.UnitTests/Components/SelectExtendedTests.cs
@@ -471,7 +471,7 @@ namespace MudExtensions.UnitTests.Components
             string.Join(",", selectedValues ?? new List<string>()).Should().Be("2");
 
             input.Click();
-            comp.WaitForAssertion(()=>comp.FindAll("div.mud-list-item-extended").Count.Should().BeGreaterThan(0));
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item-extended").Count.Should().BeGreaterThan(0));
             items = comp.FindAll("div.mud-list-item-extended").ToArray();
 
             items[0].Click();
@@ -713,7 +713,7 @@ namespace MudExtensions.UnitTests.Components
 
             comp.FindAll("div.mud-list-item-extended")[1].Click();
             // menu should be closed now
-            comp.WaitForAssertion(() => menu.ClassList.Should().NotContain("mud-popover-open"));
+            comp.WaitForAssertion(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
             comp.WaitForAssertion(() => select.Instance.Value.Should().Be("2"));
             select.Instance.Text.Should().Be("2");
             validatedValue.Should().Be("2");
@@ -1332,6 +1332,36 @@ namespace MudExtensions.UnitTests.Components
             });
             select.SelectedValues?.Count().Should().Be(1);
             select.Text.Should().Be("test");
+        }
+
+        [Test]
+        public void Select_Should_NotOpen_WhenDisabled()
+        {
+            var comp = Context.RenderComponent<SelectTest1>(parameters =>
+            {
+                parameters.Add(p => p.Disabled, true);
+            });
+            var select = comp.FindComponent<MudSelectExtended<string>>();
+            var input = comp.Find("div.mud-input-control");
+
+            // Try to open the select
+            input.Click();
+            // The menu should not open
+            comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open");
+        }
+
+        [Test]
+        public void Select_Should_NotOpen_WhenParentDisabled()
+        {
+            // Use a test component that wraps the select in a disabled parent
+            var comp = Context.RenderComponent<DisabledParentSelectTest>();
+            var select = comp.FindComponent<MudSelectExtended<string>>();
+            var input = comp.Find("div.mud-input-control");
+
+            // Try to open the select
+            input.Click();
+            // The menu should not open
+            comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open");
         }
     }
 }

--- a/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/SelectExtended/MudSelectExtended.razor.cs
@@ -850,7 +850,7 @@ namespace MudExtensions
         /// <param name="obj"></param>
         protected internal async Task HandleKeyDownAsync(KeyboardEventArgs obj)
         {
-            if (Disabled || ReadOnly)
+            if (GetDisabledState() || GetReadOnlyState())
                 return;
 
             if (_list != null && _isOpen)
@@ -997,7 +997,7 @@ namespace MudExtensions
         /// <returns></returns>
         public async Task ToggleMenu()
         {
-            if (Disabled || ReadOnly)
+            if (GetDisabledState() || GetReadOnlyState())
                 return;
             if (_isOpen)
                 await CloseMenu();
@@ -1011,7 +1011,7 @@ namespace MudExtensions
         /// <returns></returns>
         public async Task OpenMenu()
         {
-            if (Disabled || ReadOnly)
+            if (GetDisabledState() || GetReadOnlyState())
                 return;
             _isOpen = true;
             UpdateIcon();


### PR DESCRIPTION
Fixes #557 

- **`MudSelectExtended.razor.cs`**: Refactored `Disabled` and `ReadOnly` checks to use centralized methods (`GetDisabledState` and `GetReadOnlyState`). 
- **`DisabledParentSelectTest.razor`**: Added a new test component to verify `MudSelectExtended` behavior when wrapped in a disabled parent.  
- **`SelectTest1.razor`**: Added a `Disabled` parameter to `MudSelectExtended` and refactored event handling methods.  
- **`SelectExtendedTests.cs`**: Added two new test cases to validate `MudSelectExtended` behavior when disabled or when its parent is disabled.  
