### PR TITLE
Add asynchronous search support to MudComboBox

### DIFF
--- a/CodeBeam.MudBlazor.Extensions.Docs.Wasm/wwwroot/CodeBeam.MudBlazor.Extensions.xml
+++ b/CodeBeam.MudBlazor.Extensions.Docs.Wasm/wwwroot/CodeBeam.MudBlazor.Extensions.xml
@@ -1490,7 +1490,7 @@
             </summary>
             <returns></returns>
         </member>
-        <member name="M:MudExtensions.MudComboBox`1.ForceRenderItems">
+        <member name="M:MudExtensions.MudComboBox`1.ForceRenderItems(System.Threading.CancellationToken)">
             <summary>
             
             </summary>
@@ -1667,10 +1667,11 @@
             
             </summary>
         </member>
-        <member name="M:MudExtensions.MudComboBoxItem`1.ForceRender">
+        <member name="M:MudExtensions.MudComboBoxItem`1.ForceRender(System.Threading.CancellationToken)">
             <summary>
             
             </summary>
+            <param name="token"></param>
         </member>
         <member name="M:MudExtensions.MudComboBoxItem`1.ForceUpdate">
             <summary>
@@ -1695,12 +1696,13 @@
             <param name="firstRender"></param>
             <returns></returns>
         </member>
-        <member name="M:MudExtensions.MudComboBoxItem`1.CheckEligible">
+        <member name="M:MudExtensions.MudComboBoxItem`1.CheckEligible(System.Threading.CancellationToken)">
             <summary>
             
             </summary>
+            <param name="token"></param>
         </member>
-        <member name="M:MudExtensions.MudComboBoxItem`1.IsEligible">
+        <member name="M:MudExtensions.MudComboBoxItem`1.IsEligible(System.Threading.CancellationToken)">
             <summary>
             
             </summary>

--- a/CodeBeam.MudBlazor.Extensions.Docs/Pages/Components/ComboBox/Examples/ComboBoxExample8.razor
+++ b/CodeBeam.MudBlazor.Extensions.Docs/Pages/Components/ComboBox/Examples/ComboBoxExample8.razor
@@ -10,7 +10,7 @@
             <MudComboBoxItem Value="@("Buzz")" Text="Buzz">Buzz</MudComboBoxItem>
         </MudComboBox>
          <MudComboBox @bind-Value="@_value" @bind-Text="@_text" @bind-SelectedValues="@_selectedValues" Variant="Variant.Filled" ToggleSelection="true" Clearable
-                     Label="Custom (StartsWith)" Editable="true" SearchFunc="@(new Func<string?, string?, string?, bool>(SearchStartWith))" autocomplete="new-password">
+                     Label="Custom (StartsWith)" Editable="true" SearchFunc="@(new Func<string?, string?, string?, CancellationToken, Task<bool>>(SearchStartWith))" autocomplete="new-password">
             <MudComboBoxItem Value="@("Foo")" Text="Foo">Foo</MudComboBoxItem>
             <MudComboBoxItem Value="@("Bar")" Text="Bar">Bar</MudComboBoxItem>
             <MudComboBoxItem Value="@("Fizz")" Text="Fizz">Fizz</MudComboBoxItem>
@@ -24,12 +24,12 @@
     string? _text;
     IEnumerable<string>? _selectedValues;
 
-    private bool SearchStartWith(string? value, string? text, string? searchString)
+    private Task<bool> SearchStartWith(string? value, string? text, string? searchString, CancellationToken cancellationToken = default)
     {
         if (value?.StartsWith(searchString ?? "", StringComparison.OrdinalIgnoreCase) == true)
         {
-            return true;
+            return Task.FromResult(true);
         }
-        return false;
+        return Task.FromResult(false);
     }
 }

--- a/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor.cs
@@ -353,7 +353,7 @@ namespace MudExtensions
         /// </summary>
         [Parameter]
         [Category(CategoryTypes.FormComponent.ListBehavior)]
-        public Func<T?, string?, string?, bool>? SearchFunc { get; set; }
+        public Func<T?, string?, string?, CancellationToken, Task<bool>>? SearchFunc { get; set; }
 
         //[Parameter]
         //[Category(CategoryTypes.FormComponent.Behavior)]
@@ -760,12 +760,6 @@ namespace MudExtensions
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
-            if (_oldShowCheckbox != ShowCheckbox ||
-                _oldBordered != Bordered ||
-                _oldDense != Dense)
-            {
-                ForceRenderItems();
-            }
             _oldShowCheckbox = ShowCheckbox;
             _oldBordered = Bordered;
             _oldDense = Dense;
@@ -789,7 +783,7 @@ namespace MudExtensions
                 {
                     await SyncMultiselectionValues(MultiSelection);
                 }
-                ForceRenderItems();
+                await ForceRenderItems();
                 if (MultiSelection == true)
                 {
                     _searchString = null;
@@ -1461,9 +1455,13 @@ namespace MudExtensions
         /// <summary>
         /// 
         /// </summary>
-        protected internal void ForceRenderItems()
+        protected internal async Task ForceRenderItems(CancellationToken token = default)
         {
-            Items.ForEach((x) => x.ForceRender());
+            foreach (var item in Items)
+            {
+                await item.ForceRender(token).ConfigureAwait(false);
+            }
+            
             StateHasChanged();
         }
 

--- a/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBoxItem.razor.cs
+++ b/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBoxItem.razor.cs
@@ -167,9 +167,10 @@ namespace MudExtensions
         /// <summary>
         /// 
         /// </summary>
-        public void ForceRender()
+        /// <param name="token"></param>
+        public async Task ForceRender(CancellationToken token = default)
         {
-            CheckEligible();
+            await CheckEligible(token).ConfigureAwait(false);
             StateHasChanged();
         }
 
@@ -229,16 +230,18 @@ namespace MudExtensions
         /// <summary>
         /// 
         /// </summary>
-        protected internal void CheckEligible()
+        /// <param name="token"></param>
+        protected internal async Task CheckEligible(CancellationToken token = default)
         {
-            Eligible = IsEligible();
+            Eligible = await IsEligible(token)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
         /// 
         /// </summary>
         /// <returns></returns>
-        protected bool IsEligible()
+        protected async Task<bool> IsEligible(CancellationToken token =default)
         {
             if (MudComboBox is null)
                 return true;
@@ -250,7 +253,8 @@ namespace MudExtensions
                 return true;
 
             if (MudComboBox.SearchFunc is not null)
-                return MudComboBox.SearchFunc.Invoke(Value, Text, MudComboBox.GetSearchString());
+                return await MudComboBox.SearchFunc.Invoke(Value, Text, MudComboBox.GetSearchString(), token)
+                    .ConfigureAwait(false);
 
             if (!string.IsNullOrWhiteSpace(Text))
             {


### PR DESCRIPTION
Added async support with a CancellationToken to the SearchFunc.

Tests passed.

Not sure about the removed bit in the OnParametersSet, as the ForceRender is called anyway in the async version.