### PR TITLE
MudSignaturePad ClearPad Public

### DIFF
--- a/docs/CodeBeam.MudBlazor.Extensions.Docs/Pages/Components/SignaturePad/Examples/SignaturePadExample1.razor
+++ b/docs/CodeBeam.MudBlazor.Extensions.Docs/Pages/Components/SignaturePad/Examples/SignaturePadExample1.razor
@@ -1,10 +1,10 @@
 ﻿@namespace MudExtensions.Docs.Examples
 @using MudBlazor.Utilities
 @using MudExtensions.Utilities
-
+@inject IJSRuntime JsRuntime
 <MudGrid>
     <MudItem xs="12" sm="8">
-        <MudSignaturePad @bind-Value="_value" @bind-Value:after="@(() =>BytesChanged(_value))"
+        <MudSignaturePad @ref="_signaturePad" @bind-Value="_value" @bind-Value:after="@(() =>BytesChanged(_value))"
                          Options="_options"
                          ShowDownload="_showDownload"
                          ShowClear="_showClear"
@@ -32,6 +32,8 @@
             <MudSelectExtended @bind-Value="@_color" ItemCollection="@(Enum.GetValues<Color>())" Label="Color" Variant="Variant.Outlined" Margin="Margin.Dense" Dense="true" />
             <MudNumericField @bind-Value="@_elevation" Min="0" Max="25" Label="Elevation" Variant="Variant.Outlined" Margin="Margin.Dense" />
             <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="(async () => await _signaturePad.ClearPad())">Clear</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="(async () => await _signaturePad.Download())">Download</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="(async () => await _signaturePad.IsEditToggled())">Toggle edit/erase mode</MudButton>
         </MudStack>
     </MudItem>
 </MudGrid>
@@ -65,4 +67,5 @@
     {
         _value = bytes;
     }
+
 }

--- a/docs/CodeBeam.MudBlazor.Extensions.Docs/Pages/Components/SignaturePad/Examples/SignaturePadExample1.razor
+++ b/docs/CodeBeam.MudBlazor.Extensions.Docs/Pages/Components/SignaturePad/Examples/SignaturePadExample1.razor
@@ -31,6 +31,7 @@
             <MudSelectExtended @bind-Value="@_variant" ItemCollection="@(Enum.GetValues<Variant>())" Label="Variant" Variant="Variant.Outlined" Margin="Margin.Dense" Dense="true" />
             <MudSelectExtended @bind-Value="@_color" ItemCollection="@(Enum.GetValues<Color>())" Label="Color" Variant="Variant.Outlined" Margin="Margin.Dense" Dense="true" />
             <MudNumericField @bind-Value="@_elevation" Min="0" Max="25" Label="Elevation" Variant="Variant.Outlined" Margin="Margin.Dense" />
+            <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="(async () => await _signaturePad.ClearPad())">Clear</MudButton>
         </MudStack>
     </MudItem>
 </MudGrid>
@@ -46,6 +47,7 @@
     Variant _variant;
     Color _color;
     int _elevation = 4;
+    MudSignaturePad _signaturePad = null!;
 
     SignaturePadLocalizedStrings _localizedStrings = new SignaturePadLocalizedStrings();
 

--- a/src/CodeBeam.MudBlazor.Extensions/Components/SignaturePad/MudSignaturePad.razor.cs
+++ b/src/CodeBeam.MudBlazor.Extensions/Components/SignaturePad/MudSignaturePad.razor.cs
@@ -192,7 +192,11 @@ namespace MudExtensions
             await base.OnAfterRenderAsync(firstRender);
         }
 
-        private async Task IsEditToggled()
+        /// <summary>
+        /// Toggle between draw and erase mode.
+        /// </summary>
+        /// <returns></returns>
+        public async Task IsEditToggled()
         {
             await JsRuntime.InvokeVoidAsync("mudSignaturePad.togglePadEraser", _reference);
             _isErasing = !_isErasing;
@@ -207,6 +211,14 @@ namespace MudExtensions
             await ValueChanged.InvokeAsync(Array.Empty<byte>());
             await JsRuntime.InvokeVoidAsync("mudSignaturePad.clearPad", _reference);
         }
+        /// <summary>
+        /// Download the signature as an image.
+        /// </summary>
+        /// <returns></returns>
+        public async Task Download()
+        {
+            await JsRuntime.InvokeVoidAsync("mudSignaturePad.downloadPadImage", _reference);
+        }
 
         async Task PushImageUpdateToJsRuntime()
         {
@@ -218,11 +230,7 @@ namespace MudExtensions
         {
             await JsRuntime.InvokeVoidAsync("mudSignaturePad.updatePadOptions", _reference, JsOptionsStruct);
         }
-
-        async Task Download()
-        {
-            await JsRuntime.InvokeVoidAsync("mudSignaturePad.downloadPadImage", _reference);
-        }
+        
 
         private async Task LineWidthUpdated(decimal obj)
         {

--- a/src/CodeBeam.MudBlazor.Extensions/Components/SignaturePad/MudSignaturePad.razor.cs
+++ b/src/CodeBeam.MudBlazor.Extensions/Components/SignaturePad/MudSignaturePad.razor.cs
@@ -198,7 +198,11 @@ namespace MudExtensions
             _isErasing = !_isErasing;
         }
 
-        async Task ClearPad()
+        /// <summary>
+        /// Clear the signature pad.
+        /// </summary>
+        /// <returns></returns>
+        public async Task ClearPad()
         {
             await ValueChanged.InvokeAsync(Array.Empty<byte>());
             await JsRuntime.InvokeVoidAsync("mudSignaturePad.clearPad", _reference);


### PR DESCRIPTION
Making ClearPad of MudSignaturePad  a public method.


Our use case :
On a small device, having a signature pad in a modal, we remove entirely the toolbar to get the space available. And we had a button to clear the pad in the DialogActions (along with OK and cancel).

This allows us to get all the space we can for the signture pad