### PR TITLE
MudComboBox: Use `_firstRendered` to conditionally update input text in `OnParametersSetAsync`

### DIFF
--- a/src/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor.cs
+++ b/src/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor.cs
@@ -810,7 +810,7 @@ namespace MudExtensions
                 if (MultiSelection == false)
                 {
                     _searchString = ConvertSet(ReadValue);
-                    if (_inputReference != null)
+                    if (_firstRendered)
                     {
                         await _inputReference?.SetText(_searchString);
                     }

--- a/src/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor.cs
+++ b/src/CodeBeam.MudBlazor.Extensions/Components/ComboBox/MudComboBox.razor.cs
@@ -810,9 +810,9 @@ namespace MudExtensions
                 if (MultiSelection == false)
                 {
                     _searchString = ConvertSet(ReadValue);
-                    if (_firstRendered)
+                    if (_inputReference != null)
                     {
-                        await _inputReference?.SetText(_searchString);
+                        await SetTextCoreAsync(_searchString);
                     }
                 }
             }


### PR DESCRIPTION
Prevents StateHasChanged called before component is fully initialized. Fixes #600 