### PR TITLE
Improve MudListItemExtended Accessibility

### DIFF
--- a/docs/CodeBeam.MudBlazor.Extensions.Docs.Wasm/wwwroot/CodeBeam.MudBlazor.Extensions.xml
+++ b/docs/CodeBeam.MudBlazor.Extensions.Docs.Wasm/wwwroot/CodeBeam.MudBlazor.Extensions.xml
@@ -2699,6 +2699,12 @@
             
             </summary>
         </member>
+        <member name="P:MudExtensions.MudListItemExtended`1.AccessibleName">
+            <summary>
+            The accessible name used for the item. Prefer Text, then SecondaryText, then Value.ToString().
+            If the parent list has a ToStringFunc use that for Value formatting.
+            </summary>
+        </member>
         <member name="P:MudExtensions.MudListItemExtended`1.IsFunctional">
             <summary>
             Functional items does not hold values. If a value set on Functional item, it ignores by the MudList. They can not count on Items list (they count on AllItems), cannot be subject of keyboard navigation and selection.

--- a/src/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListItemExtended.razor
+++ b/src/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListItemExtended.razor
@@ -82,15 +82,18 @@
                 <div class="@MultiSelectClassName">
                     @if (OverrideMultiSelectionComponent == null ? MudListExtended?.MultiSelectionComponent == MultiSelectionComponent.CheckBox : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.CheckBox)
                     {
-                        <MudCheckBox Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" Dense="true" />
+                        <MudCheckBox Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" Dense="true"
+                                     aria-label="@($"Select {AccessibleName}")" />
                     }
                     else if (OverrideMultiSelectionComponent == null ? MudListExtended?.MultiSelectionComponent == MultiSelectionComponent.Switch : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.Switch)
                     {
-                        <MudSwitch Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" StopClickPropagation="true" />
+                        <MudSwitch Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" StopClickPropagation="true"
+                                   aria-label="@($"Select {AccessibleName}")" />
                     }
                     else if (OverrideMultiSelectionComponent == null ? MudListExtended?.MultiSelectionComponent == MultiSelectionComponent.SwitchM3 : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.SwitchM3)
                     {
-                        <MudSwitchM3 Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" StopClickPropagation="true" />
+                        <MudSwitchM3 Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" StopClickPropagation="true"
+                                   aria-label="@($"Select {AccessibleName}")" />
                     }
                 </div>
             }

--- a/src/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListItemExtended.razor
+++ b/src/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListItemExtended.razor
@@ -32,17 +32,17 @@
                     @if (OverrideMultiSelectionComponent == null ? MudListExtended?.MultiSelectionComponent == MultiSelectionComponent.CheckBox : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.CheckBox)
                     {
                         <MudCheckBox Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" Dense="true"
-                                     aria-label="@AccessibleName" />
+                                     aria-label="@($"Select {AccessibleName}")" />
                     }
                     else if (OverrideMultiSelectionComponent == null ? MudListExtended?.MultiSelectionComponent == MultiSelectionComponent.Switch : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.Switch)
                     {
                         <MudSwitch Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" StopClickPropagation="true"
-                                   aria-label="@AccessibleName" />
+                                   aria-label="@($"Select {AccessibleName}")" />
                     }
                     else if (OverrideMultiSelectionComponent == null ? MudListExtended?.MultiSelectionComponent == MultiSelectionComponent.SwitchM3 : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.SwitchM3)
                     {
                         <MudSwitchM3 Class="mr-4" Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" StopClickPropagation="true"
-                                   aria-label="@AccessibleName" />
+                                   aria-label="@($"Select {AccessibleName}")" />
                     }
                 </div>
             }

--- a/src/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListItemExtended.razor
+++ b/src/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListItemExtended.razor
@@ -5,10 +5,14 @@
 
 @if (IsVisible)
 {
-    <div tabindex="0" @attributes="UserAttributes" id="@ItemId" class="@Classname" @onclick="@(((MudListExtended?.Clickable == true || NestedList != null) && IsFunctional == false) ? OnClickHandler : OnlyOnClick)" @onclick:stopPropagation="@OnClickStopPropagation" style="@Style">
+    <div tabindex="0" @attributes="UserAttributes" id="@ItemId" class="@Classname"
+         role="option"
+         aria-selected="@(_selected ? "true" : "false")"
+         aria-label="@AccessibleName"
+         @onclick="@(((MudListExtended?.Clickable == true || NestedList != null) && IsFunctional == false) ? OnClickHandler : OnlyOnClick)" @onclick:stopPropagation="@OnClickStopPropagation" style="@Style">
 
         @if (MudListExtended?.ItemDisabledTemplate != null && GetDisabledStatus() == true)
-        {
+        { 
             @MudListExtended.ItemDisabledTemplate(this)
         }
         else if (MudListExtended?.ItemSelectedTemplate != null && IsSelected == true)
@@ -27,15 +31,18 @@
                 <div class="@MultiSelectClassName">
                     @if (OverrideMultiSelectionComponent == null ? MudListExtended?.MultiSelectionComponent == MultiSelectionComponent.CheckBox : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.CheckBox)
                     {
-                        <MudCheckBox Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" Dense="true" />
+                        <MudCheckBox Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" Dense="true"
+                                     aria-label="@AccessibleName" />
                     }
                     else if (OverrideMultiSelectionComponent == null ? MudListExtended?.MultiSelectionComponent == MultiSelectionComponent.Switch : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.Switch)
                     {
-                        <MudSwitch Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" StopClickPropagation="true" />
+                        <MudSwitch Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" StopClickPropagation="true"
+                                   aria-label="@AccessibleName" />
                     }
                     else if (OverrideMultiSelectionComponent == null ? MudListExtended?.MultiSelectionComponent == MultiSelectionComponent.SwitchM3 : OverrideMultiSelectionComponent.Value == MultiSelectionComponent.SwitchM3)
                     {
-                        <MudSwitchM3 Class="mr-4" Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" StopClickPropagation="true" />
+                        <MudSwitchM3 Class="mr-4" Color="@(MudListExtended?.Color ?? Color.Default)" Disabled="@GetDisabledStatus()" @bind-Value="_selected" @onclick="OnClickHandler" StopClickPropagation="true"
+                                   aria-label="@AccessibleName" />
                     }
                 </div>
             }

--- a/src/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListItemExtended.razor.cs
+++ b/src/CodeBeam.MudBlazor.Extensions/Components/ListExtended/MudListItemExtended.razor.cs
@@ -1,7 +1,5 @@
-﻿using System.Windows.Input;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
-using MudBlazor.Extensions;
 using MudBlazor.Utilities;
 using MudBlazor;
 
@@ -59,7 +57,29 @@ namespace MudExtensions
         /// <summary>
         /// 
         /// </summary>
-        protected internal string? ItemId { get; } = "listitem_" + Guid.NewGuid().ToString().Substring(0, 8);
+        protected internal string? ItemId { get; } = string.Concat("listitem_", Guid.NewGuid().ToString().AsSpan(0, 8));
+
+        /// <summary>
+        /// The accessible name used for the item. Prefer Text, then SecondaryText, then Value.ToString().
+        /// If the parent list has a ToStringFunc use that for Value formatting.
+        /// </summary>
+        protected string AccessibleName
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(Text))
+                    return Text!;
+                if (!string.IsNullOrWhiteSpace(SecondaryText))
+                    return SecondaryText!;
+                if (Value != null)
+                {
+                    if (MudListExtended?.ToStringFunc != null)
+                        return MudListExtended.ToStringFunc(Value) ?? Value.ToString() ?? string.Empty;
+                    return Value.ToString() ?? string.Empty;
+                }
+                return string.Empty;
+            }
+        }
 
         /// <summary>
         /// Functional items does not hold values. If a value set on Functional item, it ignores by the MudList. They can not count on Items list (they count on AllItems), cannot be subject of keyboard navigation and selection.

--- a/tests/CodeBeam.MudBlazor.Extensions.UnitTests/Components/SelectExtendedTests.cs
+++ b/tests/CodeBeam.MudBlazor.Extensions.UnitTests/Components/SelectExtendedTests.cs
@@ -57,11 +57,11 @@ namespace MudExtensions.UnitTests.Components
             item.GetAttribute("role").Should().Be("option");
             var checkbox = item.QuerySelector("input[type=checkbox]");
             checkbox.Should().NotBeNull();
-            var ariaLabel = checkbox.GetAttribute("aria-label");
-            ariaLabel.Should().NotBeNullOrEmpty();
             var optionAria = item.GetAttribute("aria-label");
             optionAria.Should().NotBeNullOrEmpty();
-            optionAria.Trim().Should().Be(ariaLabel.Trim());
+            var checkboxAria = checkbox.GetAttribute("aria-label");
+            checkboxAria.Should().NotBeNullOrEmpty();
+            checkboxAria.Trim().Should().Be($"Select {optionAria.Trim()}");
         }
 
         // Note: MudSelect doesn't guaranteed the consequences of changing Value if MultiSelection is true for now.

--- a/tests/CodeBeam.MudBlazor.Extensions.UnitTests/Components/SelectExtendedTests.cs
+++ b/tests/CodeBeam.MudBlazor.Extensions.UnitTests/Components/SelectExtendedTests.cs
@@ -29,6 +29,41 @@ namespace MudExtensions.UnitTests.Components
             label[0].Attributes.GetNamedItem("for")?.Value.Should().Be("selectLabelTest");
         }
 
+        [Test]
+        public void Select_Items_Should_Expose_Accessible_Role_And_Label()
+        {
+            var comp = Context.Render<SelectTest1>();
+            comp.Find("div.mud-input-control").Click();
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item-extended").Count.Should().BeGreaterThan(0));
+
+            var items = comp.FindAll("div.mud-list-item-extended").ToArray();
+            var item = items[1];
+            item.GetAttribute("role").Should().Be("option");
+            item.GetAttribute("aria-selected").Should().Be("false");
+            var ariaLabel = item.GetAttribute("aria-label");
+            ariaLabel.Should().NotBeNullOrEmpty();
+            ariaLabel.Trim().Should().Be("2");
+        }
+
+        [Test]
+        public void MultiSelect_Items_Should_Expose_Checkbox_AriaLabel_And_TestId()
+        {
+            var comp = Context.Render<MultiSelectTest1>();
+            comp.Find("div.mud-input-control").Click();
+            comp.WaitForAssertion(() => comp.FindAll("div.mud-list-item-extended").Count.Should().BeGreaterThan(0));
+
+            var items = comp.FindAll("div.mud-list-item-extended").ToArray();
+            var item = items[1];
+            item.GetAttribute("role").Should().Be("option");
+            var checkbox = item.QuerySelector("input[type=checkbox]");
+            checkbox.Should().NotBeNull();
+            var ariaLabel = checkbox.GetAttribute("aria-label");
+            ariaLabel.Should().NotBeNullOrEmpty();
+            var optionAria = item.GetAttribute("aria-label");
+            optionAria.Should().NotBeNullOrEmpty();
+            optionAria.Trim().Should().Be(ariaLabel.Trim());
+        }
+
         // Note: MudSelect doesn't guaranteed the consequences of changing Value if MultiSelection is true for now.
         // When this feature will add, just uncomment the testcase to test it. No need to write new test.
         [Test]


### PR DESCRIPTION
**Why**
•	Improves screen-reader/test automation behavior and overall ARIA semantics for MudListItems and associated checkboxes.

**What changed**
•	Added a new AccessibleName property to MudListItemExtended and wired it into aria-label.
•	Added role and aria-selected attributes to MudListItemExtended for correct semantics.
•	Added checkbox aria-label identification

**Migration notes**
•	No breaking changes. Consumers who want custom accessible labels can set AccessibleName on MudListItemExtended to provide an explicit aria-label.