### PR TITLE
Fix code viewer editor when line numbers are enabled

### DIFF
--- a/docs/CodeBeam.MudBlazor.Extensions.Docs/Pages/Components/CodeViewer/Examples/CodeViewerExample4.razor
+++ b/docs/CodeBeam.MudBlazor.Extensions.Docs/Pages/Components/CodeViewer/Examples/CodeViewerExample4.razor
@@ -2,17 +2,21 @@
 
 <MudGrid>
     <MudItem xs="12" sm="8" Class="d-flex flex-column gap-8 align-center justify-center">
-        <MudCodeViewer Class="mud-width-full" Code="@_code" Editable="@_editable" />
+        <MudCodeViewer Class="mud-width-full" Code="@_code" Editable="@_editable" ShowLineNumbers="@_showLineNumbers" />
     </MudItem>
 
     <MudItem xs="12" sm="4">
-        <MudSwitchM3 @bind-Value="@_editable" Label="Editable" Color="Color.Secondary" />
+        <MudStack Spacing="2">
+            <MudSwitchM3 @bind-Value="@_editable" Label="Editable" Color="Color.Secondary"/>
+            <MudSwitchM3 @bind-Value="@_showLineNumbers" Label="Line Numbers" Color="Color.Secondary"/>
+        </MudStack>
     </MudItem>
 </MudGrid>
 
 
 @code {
     private bool _editable = true;
+    private bool _showLineNumbers = false;
     private string _code = """
 // This is a sample code as string parameter.
 public class MudCodeViewer

--- a/src/CodeBeam.MudBlazor.Extensions.Code/Components/MudCodeViewer.razor
+++ b/src/CodeBeam.MudBlazor.Extensions.Code/Components/MudCodeViewer.razor
@@ -45,7 +45,7 @@
                     </code>
                 </pre>
 
-                <textarea @ref="_textAreaRef" class="mud-codeviewer-textarea" @bind="Code" @oninput="OnInput"
+                <textarea @ref="_textAreaRef" class="@TextAreaClass" @bind="Code" @oninput="OnInput"
                           spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off"></textarea>
             </div>
         }

--- a/src/CodeBeam.MudBlazor.Extensions.Code/Components/MudCodeViewer.razor.cs
+++ b/src/CodeBeam.MudBlazor.Extensions.Code/Components/MudCodeViewer.razor.cs
@@ -80,6 +80,14 @@ public partial class MudCodeViewer : MudComponentBase
         .Build();
 
     /// <summary>
+    /// Gets the CSS class string used for the textarea element based on the line number display settings.
+    /// </summary>
+    private string TextAreaClass => new CssBuilder()
+        .AddClass("mud-codeviewer-textarea")
+        .AddClass("line-numbers", _showLineNumbers.Value)
+        .Build();
+
+    /// <summary>
     /// Gets or sets the code snippet to be displayed or processed by the component.
     /// </summary>
     [Parameter]

--- a/src/CodeBeam.MudBlazor.Extensions.Code/wwwroot/prism/prism.min.css
+++ b/src/CodeBeam.MudBlazor.Extensions.Code/wwwroot/prism/prism.min.css
@@ -87,3 +87,7 @@ pre[class*=language-].line-numbers{position:relative;padding-left:3.8em;counter-
     font: inherit;
     padding: 16px;
 }
+
+.mud-codeviewer-textarea.line-numbers {
+    padding-left: 3.8em
+}


### PR DESCRIPTION
When `ShowLineNumbers` and `Editable` are both set to `true` on the `MudCodViewer`, there is a shift between the caret and the shown highlighted content.

This is due to the fact that the `<pre>` overlay is shifted right by `3.8em` and the underlying `<textarea>` is not. So there is effectively a shift of 3.8em between the caret and the shown highlighted content.

I encountered the issue in my project and it has also been reported in issue #628.

The fix adds a new style for the `<textarea>` and applies it dynamically when `ShowLineNumbers` is `true` (as it was already done for the `<pre>`)

The 4th doc sample example has also been updated to allow enabling line numbers when in edit mode.